### PR TITLE
Prepare notification bitand workaround for postgreSQL

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/dto/data/notifications/NotificationDTO.java
+++ b/tesler-core/src/main/java/io/tesler/core/dto/data/notifications/NotificationDTO.java
@@ -67,7 +67,9 @@ public class NotificationDTO extends DataResponseDTO {
 		this.url = entity.getUrl();
 		this.createdDate = entity.getCreatedDate();
 		this.read = entity.isRead();
-		this.mimeType = entity.getMimeType().getKey();
+		if (entity.getMimeType() != null) {
+			this.mimeType = entity.getMimeType().getKey();
+		}
 	}
 
 }

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/notifications/Notification.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/notifications/Notification.java
@@ -64,10 +64,10 @@ public class Notification extends BaseEntity {
 	private String uiMessage;
 
 	@Formula("BITAND(DELIVERY_STATUS, 1)")
-	private boolean read;
+	private Integer read;
 
 	@Formula("BITAND(DELIVERY_TYPE, 1)")
-	private boolean push;
+	private Integer push;
 
 	@Column(name = "URL")
 	private String url;
@@ -92,6 +92,14 @@ public class Notification extends BaseEntity {
 	public final void prePersist() {
 		this.subject = StringUtils.truncate(this.subject, 1500);
 		this.uiSubject = StringUtils.truncate(this.uiSubject, 1500);
+	}
+
+	public boolean isRead() {
+		return read == 1;
+	}
+
+	public boolean isPush() {
+		return push == 1;
 	}
 
 }


### PR DESCRIPTION
* Notification read and push fields now are integers. Add methods isRead() and isPush() for backward  сompatibility.
* Fix NPE with notification without mime-type, generated with save-notification endpoint
* Remove orderBy clause for count-notifications search spec