### PR TITLE
New `/screens` endpoint with available screens formerly extracted from `/login` endpoint (#68)

### DIFF
--- a/tesler-base/pom.xml
+++ b/tesler-base/pom.xml
@@ -273,6 +273,19 @@
         <version>0.15</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>2.2.6.RELEASE</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-test</artifactId>
+        <version>5.3.1.RELEASE</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/tesler-core/pom.xml
+++ b/tesler-core/pom.xml
@@ -182,9 +182,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <version>2.0.1.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
     </dependency>
   </dependencies>
 

--- a/tesler-core/src/main/java/io/tesler/core/controller/LoginController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/LoginController.java
@@ -64,6 +64,16 @@ public class LoginController {
 
 	private final CoreSessionService coreSessionService;
 
+	/**
+	 * Authenticate user in the application; actual authentication performed by Spring Security in client app
+	 *
+	 * @param request
+	 * @param response
+	 * @param role Required role; TODO: Used to switch role from UI, consider separate endpoint for that
+	 * @param timezone
+	 * @param locale Required locale TODO: Consider separate endpoint to switch language from UI
+	 * @return
+	 */
 	@RequestMapping(method = RequestMethod.GET, value = "/login")
 	public LoggedUser get(
 			HttpServletRequest request,
@@ -75,6 +85,11 @@ public class LoginController {
 		return loginService.getLoggedUser(role);
 	}
 
+	/**
+	 * Logout endpoint, actual session is usually cleared by client application by specifying this endpoint as
+	 * `logoutUrl` of Spring Security configuration
+	 * @return Empty list
+	 */
 	@RequestMapping(method = RequestMethod.GET, value = "/logout")
 	public ResponseDTO logout() {
 		return resp.build(new ArrayList<>());
@@ -99,13 +114,13 @@ public class LoginController {
 
 	protected Locale getLocale(LocaleContext context, LocaleSpecification locale) {
 		List<Locale> candidates = new ArrayList<>();
-		// явно указанное в запросе
+		// explicitly specified in request
 		Optional.ofNullable(locale).map(LocaleSpecification::getLocale).map(LOV::getKey)
 				.map(StringUtils::parseLocaleString).ifPresent(candidates::add);
-		// настройки пользователя
+		// user settings
 		Optional.ofNullable(coreSessionService.getLocale(null))
 				.ifPresent(candidates::add);
-		// информация из браузера (куки или Accept-language)
+		// browser information (cookies or Accept-language)
 		Optional.of(context.getLocale()).ifPresent(candidates::add);
 		return candidates.stream().filter(
 				l -> localeService.isLanguageSupported(l.getLanguage())

--- a/tesler-core/src/main/java/io/tesler/core/controller/ScreenController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/ScreenController.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.controller;
+
+import io.tesler.core.dto.data.view.ScreenResponsibility;
+import io.tesler.core.service.ScreenResponsibilityService;
+import io.tesler.core.util.session.SessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ScreenController {
+
+	private final ScreenResponsibilityService screenResponsibilityService;
+
+	private final SessionService sessionService;
+
+	/**
+	 * Should be called by authenticated user for a list of available screens
+	 *
+	 * @return Available screens and their meta information
+	 */
+	@RequestMapping(method = RequestMethod.GET, value = "/screens")
+	public List<ScreenResponsibility> getScreens() {
+		return screenResponsibilityService.getScreens(sessionService.getSessionUser(), sessionService.getSessionUserRole());
+	}
+}

--- a/tesler-core/src/main/java/io/tesler/core/controller/ScreenController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/ScreenController.java
@@ -24,8 +24,7 @@ import io.tesler.core.dto.data.view.ScreenResponsibility;
 import io.tesler.core.service.ScreenResponsibilityService;
 import io.tesler.core.util.session.SessionService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -43,7 +42,7 @@ public class ScreenController {
 	 *
 	 * @return Available screens and their meta information
 	 */
-	@RequestMapping(method = RequestMethod.GET, value = "/screens")
+	@GetMapping("/screens")
 	public List<ScreenResponsibility> getScreens() {
 		return screenResponsibilityService.getScreens(sessionService.getSessionUser(), sessionService.getSessionUserRole());
 	}

--- a/tesler-core/src/main/java/io/tesler/core/dto/LoggedUser.java
+++ b/tesler-core/src/main/java/io/tesler/core/dto/LoggedUser.java
@@ -60,6 +60,7 @@ public class LoggedUser {
 	/**
 	 * @deprecated TODO: Remove in 3.0 in favor of separate ScreenController endpoint
 	 */
+	@Deprecated
 	private List<ScreenResponsibility> screens;
 
 	private JsonNode userSettingsVersion;

--- a/tesler-core/src/main/java/io/tesler/core/dto/LoggedUser.java
+++ b/tesler-core/src/main/java/io/tesler/core/dto/LoggedUser.java
@@ -57,6 +57,9 @@ public class LoggedUser {
 
 	private List<SimpleDictionary> roles;
 
+	/**
+	 * @deprecated TODO: Remove in 3.0 in favor of separate ScreenController endpoint
+	 */
 	private List<ScreenResponsibility> screens;
 
 	private JsonNode userSettingsVersion;

--- a/tesler-core/src/main/java/io/tesler/core/service/ScreenResponsibilityService.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/ScreenResponsibilityService.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.service;
+
+import io.tesler.api.data.dictionary.LOV;
+import io.tesler.core.dto.data.view.ScreenResponsibility;
+import io.tesler.model.core.entity.User;
+
+import java.util.List;
+
+public interface ScreenResponsibilityService {
+	List<ScreenResponsibility> getScreens(User user, LOV userRole);
+}

--- a/tesler-core/src/main/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImpl.java
@@ -20,6 +20,7 @@
 
 package io.tesler.core.service.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tesler.api.data.dictionary.LOV;
 import io.tesler.core.dto.data.view.ScreenDTO;
 import io.tesler.core.dto.data.view.ScreenResponsibility;
@@ -27,11 +28,11 @@ import io.tesler.core.service.ResponsibilitiesService;
 import io.tesler.core.service.ScreenResponsibilityService;
 import io.tesler.core.service.UIService;
 import io.tesler.core.service.ViewService;
-import io.tesler.core.util.jackson.CustomObjectMapper;
 import io.tesler.model.core.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,7 +46,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ScreenResponsibilityServiceImpl implements ScreenResponsibilityService {
 
-	private final CustomObjectMapper objectMapper;
+	@Qualifier("teslerObjectMapper")
+	private final ObjectMapper objectMapper;
 
 	private final ResponsibilitiesService respService;
 

--- a/tesler-core/src/main/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImpl.java
@@ -64,8 +64,8 @@ public class ScreenResponsibilityServiceImpl implements ScreenResponsibilityServ
 	 */
 	@Override
 	public List<ScreenResponsibility> getScreens(User user, LOV userRole) {
+		List<ScreenResponsibility> result = new ArrayList<>();
 		try {
-			List<ScreenResponsibility> result = new ArrayList<>();
 			String screens = respService.getListScreensByUser(user, userRole);
 			if (StringUtils.isNotBlank(screens)) {
 				result.addAll(objectMapper.readValue(screens, ScreenResponsibility.LIST_TYPE_REFERENCE));
@@ -84,6 +84,6 @@ public class ScreenResponsibilityServiceImpl implements ScreenResponsibilityServ
 			log.error(e.getLocalizedMessage(), e);
 		}
 
-		return null;
+		return result;
 	}
 }

--- a/tesler-core/src/main/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImpl.java
@@ -1,0 +1,87 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.service.impl;
+
+import io.tesler.api.data.dictionary.LOV;
+import io.tesler.core.dto.data.view.ScreenDTO;
+import io.tesler.core.dto.data.view.ScreenResponsibility;
+import io.tesler.core.service.ResponsibilitiesService;
+import io.tesler.core.service.ScreenResponsibilityService;
+import io.tesler.core.service.UIService;
+import io.tesler.core.service.ViewService;
+import io.tesler.core.util.jackson.CustomObjectMapper;
+import io.tesler.model.core.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ScreenResponsibilityServiceImpl implements ScreenResponsibilityService {
+
+	private final CustomObjectMapper objectMapper;
+
+	private final ResponsibilitiesService respService;
+
+	private final UIService uiService;
+
+	private final ViewService viewService;
+
+	/**
+	 * Get all available screens with respect of user role
+	 *
+	 * @param user Active session user
+	 * @param userRole User role
+	 * @return JsonNode Available screens
+	 */
+	@Override
+	public List<ScreenResponsibility> getScreens(User user, LOV userRole) {
+		try {
+			List<ScreenResponsibility> result = new ArrayList<>();
+			String screens = respService.getListScreensByUser(user, userRole);
+			if (StringUtils.isNotBlank(screens)) {
+				result.addAll(objectMapper.readValue(screens, ScreenResponsibility.LIST_TYPE_REFERENCE));
+			}
+			List<ScreenResponsibility> commonScreens = uiService.getCommonScreens();
+			if (commonScreens != null) {
+				result.addAll(commonScreens);
+			}
+			result.forEach(resp -> {
+				String screenName = resp.getName();
+				ScreenDTO screenDto = viewService.getScreen(screenName);
+				resp.setMeta(screenDto);
+			});
+			return result;
+		} catch (IOException e) {
+			log.error(e.getLocalizedMessage(), e);
+		}
+
+		return null;
+	}
+}

--- a/tesler-core/src/main/java/io/tesler/core/util/session/impl/LoginServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/util/session/impl/LoginServiceImpl.java
@@ -26,24 +26,18 @@ import io.tesler.api.data.dictionary.LOV;
 import io.tesler.api.data.dictionary.SimpleDictionary;
 import io.tesler.api.system.SystemSettings;
 import io.tesler.core.dto.LoggedUser;
-import io.tesler.core.dto.data.view.ScreenDTO;
 import io.tesler.core.dto.data.view.ScreenResponsibility;
+import io.tesler.core.service.ScreenResponsibilityService;
 import io.tesler.core.service.UIService;
-import io.tesler.core.service.ViewService;
-import io.tesler.core.service.ResponsibilitiesService;
 import io.tesler.core.service.impl.UserRoleService;
 import io.tesler.core.util.session.LoginService;
 import io.tesler.core.util.session.SessionService;
 import io.tesler.model.core.entity.User;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,26 +49,21 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LoginServiceImpl implements LoginService {
 
-	@Qualifier("teslerObjectMapper")
-	private final ObjectMapper objectMapper;
-
 	private final SessionService sessionService;
 
 	private final UserRoleService userRoleService;
-
-	private final ResponsibilitiesService respService;
 
 	private final SystemSettings systemSettings;
 
 	private final UIService uiService;
 
-	private final ViewService viewService;
+	private final ScreenResponsibilityService screenResponsibilityService;
 
 	/**
-	 * Получить информацию о пользователе
+	 * Build info for active session user for specific role
 	 *
-	 * @param role Роль
-	 * @return LoggedUser
+	 * @param role Requested role
+	 * @return LoggedUser User info with settings, supported features, locale and time zone
 	 */
 	@Override
 	public LoggedUser getLoggedUser(String role) {
@@ -89,6 +78,7 @@ public class LoginServiceImpl implements LoginService {
 				.user(user)
 				.activeRole(activeUserRole.getKey())
 				.roles(userRoleService.getUserRoles(user))
+				// TODO: Remove screens from response in 3.0 in favor of separate ScreenController endpoint
 				.screens(getScreens(user, activeUserRole))
 				.userSettings(uiService.getUserSettings())
 				.featureSettings(this.getFeatureSettings())
@@ -99,45 +89,27 @@ public class LoginServiceImpl implements LoginService {
 	}
 
 	/**
-	 * Получить список доступных экранов пользователя в соответствии с ролью
+	 * Get all available screens with respect of user role
+	 * @deprecated TODO: Remove in 3.0 in favor of separate ScreenController endpoint
 	 *
-	 * @param user Пользователь
-	 * @param userRole Роль
-	 * @return JsonNode
+	 * @param user Active session user
+	 * @param userRole User role
+	 * @return JsonNode Available screens
 	 */
 	private List<ScreenResponsibility> getScreens(User user, LOV userRole) {
-		try {
-			List<ScreenResponsibility> result = new ArrayList<>();
-			String screens = respService.getListScreensByUser(user, userRole);
-			if (StringUtils.isNotBlank(screens)) {
-				result.addAll(objectMapper.readValue(screens, ScreenResponsibility.LIST_TYPE_REFERENCE));
-			}
-			List<ScreenResponsibility> commonScreens = uiService.getCommonScreens();
-			if (commonScreens != null) {
-				result.addAll(commonScreens);
-			}
-			result.forEach(resp -> {
-				String screenName = resp.getName();
-				ScreenDTO screenDto = viewService.getScreen(screenName);
-				resp.setMeta(screenDto);
-			});
-			return result;
-		} catch (IOException e) {
-			log.error(e.getLocalizedMessage(), e);
-		}
-
-		return null;
+		return screenResponsibilityService.getScreens(user, userRole);
 	}
 
 	/**
-	 * Получить список доступных функциональностей
+	 * Get available application features, e.g. comments/notification polling or supression of system errors
+	 * No implementation is provided by Tesler UI by default so for now it is considered as a customization joint.
 	 *
-	 * @return List
+	 * @return Dictionary of string key and value (boolean)
+	 * Following keys were supported historically: FEATURE_COMMENTS, FEATURE_NOTIFICATIONS, FEATURE_HIDE_SYSTEM_ERRORS
 	 */
 	public Collection<SimpleDictionary> getFeatureSettings() {
 		return systemSettings.select(key -> key.startsWith("FEATURE_"))
 				.map(p -> new SimpleDictionary(p.getKey(), p.getValue()))
 				.collect(Collectors.toList());
 	}
-
 }

--- a/tesler-core/src/main/java/io/tesler/core/util/session/impl/LoginServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/util/session/impl/LoginServiceImpl.java
@@ -20,7 +20,6 @@
 
 package io.tesler.core.util.session.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tesler.api.data.dictionary.CoreDictionaries.SystemPref;
 import io.tesler.api.data.dictionary.LOV;
 import io.tesler.api.data.dictionary.SimpleDictionary;

--- a/tesler-core/src/main/java/io/tesler/core/util/session/impl/LoginServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/util/session/impl/LoginServiceImpl.java
@@ -95,6 +95,7 @@ public class LoginServiceImpl implements LoginService {
 	 * @param userRole User role
 	 * @return JsonNode Available screens
 	 */
+	@Deprecated
 	private List<ScreenResponsibility> getScreens(User user, LOV userRole) {
 		return screenResponsibilityService.getScreens(user, userRole);
 	}

--- a/tesler-core/src/test/java/io/tesler/core/TestApplication.java
+++ b/tesler-core/src/test/java/io/tesler/core/TestApplication.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+	public static void main(String... args) {
+		SpringApplication.run(TestApplication.class);
+	}
+}

--- a/tesler-core/src/test/java/io/tesler/core/controller/ScreenControllerTest.java
+++ b/tesler-core/src/test/java/io/tesler/core/controller/ScreenControllerTest.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.controller;
+
+import io.tesler.core.dto.data.view.ScreenResponsibility;
+import io.tesler.core.exception.ExceptionHandlerSettings;
+import io.tesler.core.service.ScreenResponsibilityService;
+import io.tesler.core.util.session.SessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ScreenController.class)
+public class ScreenControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private ScreenResponsibilityService screenResponsibilityService;
+
+	@MockBean
+	private SessionService sessionService;
+
+	@MockBean
+	ExceptionHandlerSettings exceptionHandlerSettingsæ;
+
+	private final String expectedResponse = "[{\"id\":null,\"name\":\"screen1\",\"text\":null,\"url\":null,\"icon\":null,\"defaultScreen\":false,\"meta\":null},{\"id\":null,\"name\":\"screen2\",\"text\":null,\"url\":null,\"icon\":null,\"defaultScreen\":false,\"meta\":null}]";
+
+	@Test
+	@WithMockUser(username = "vanilla", password = "vanilla")
+	@SneakyThrows
+	void controllerExists() {
+		this.mockMvc.perform(get("/screens")).andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser(username = "vanilla", password = "vanilla")
+	@SneakyThrows
+	void controllerCallsService() {
+		ScreenResponsibility screen1 = new ScreenResponsibility();
+		ScreenResponsibility screen2 = new ScreenResponsibility();
+		screen1.setName("screen1");
+		screen2.setName("screen2");
+		when(screenResponsibilityService.getScreens(null, null)).thenReturn(Arrays.asList(screen1, screen2));
+		this.mockMvc.perform(get("/screens"))
+				.andDo(print())
+				.andExpect(
+						content().json(expectedResponse)
+				);
+	}
+}

--- a/tesler-core/src/test/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImplTest.java
+++ b/tesler-core/src/test/java/io/tesler/core/service/impl/ScreenResponsibilityServiceImplTest.java
@@ -1,0 +1,131 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.service.impl;
+
+import io.tesler.core.config.JacksonConfig;
+import io.tesler.core.dto.data.view.ScreenDTO;
+import io.tesler.core.dto.data.view.ScreenResponsibility;
+import io.tesler.core.service.ResponsibilitiesService;
+import io.tesler.core.service.UIService;
+import io.tesler.core.service.ViewService;
+import io.tesler.model.ui.entity.Screen;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringJUnitConfig({
+		ScreenResponsibilityServiceImpl.class,
+		JacksonConfig.class
+})
+public class ScreenResponsibilityServiceImplTest {
+
+	@MockBean
+	private ResponsibilitiesService respService;
+
+	@MockBean
+	private UIService uiService;
+
+	@MockBean
+	private ViewService viewService;
+
+	@InjectMocks
+	@Autowired
+	private ScreenResponsibilityServiceImpl screenResponsibilityService;
+
+	@Test
+	public void getScreens() {
+		Screen screenExample = new Screen();
+		screenExample.setId(1L);
+		ScreenDTO screenMetaExample = new ScreenDTO(screenExample);
+		when(respService.getListScreensByUser(null, null)).thenReturn(getRespServiceResponse());
+		when(uiService.getCommonScreens()).thenReturn(getUiServiceResponse());
+		when(viewService.getScreen(anyString())).thenReturn(screenMetaExample);
+		List<ScreenResponsibility> screens = screenResponsibilityService.getScreens(null, null);
+		assertThat(screens).isNotNull();
+		assertThat(screens.size()).isEqualTo(5);
+		assertThat(screens.get(0).getUrl()).isEqualTo("/screen/getting-started");
+		assertThat(screens.get(4).getUrl()).isEqualTo("/screen/api-reference");
+		assertThat(screens.get(0).getMeta()).isEqualTo(screenMetaExample);
+	}
+
+	@Test
+	public void getScreensEmpty() {
+		when(respService.getListScreensByUser(null, null)).thenReturn("");
+		when(uiService.getCommonScreens()).thenReturn(null);
+		List<ScreenResponsibility> screens = screenResponsibilityService.getScreens(null, null);
+		assertThat(screens).isNotNull();
+		assertThat(screens.size()).isEqualTo(0);
+	}
+
+	@Test
+	public void respServiceInvalidJson() {
+		when(respService.getListScreensByUser(null, null)).thenReturn("][");
+		List<ScreenResponsibility> result = screenResponsibilityService.getScreens(null, null);
+		assertThat(result).isNotNull();
+		assertThat(result.isEmpty()).isTrue();
+	}
+
+	private String getRespServiceResponse() {
+		return "[\n" +
+				"    {\n" +
+				"      \"name\": \"getting-started\",\n" +
+				"      \"text\": \"Getting Started\",\n" +
+				"      \"icon\": \"rocket\",\n" +
+				"      \"url\": \"/screen/getting-started\"\n" +
+				"    },\n" +
+				"    {\n" +
+				"      \"name\": \"tutorial\",\n" +
+				"      \"text\": \"Tutorial\",\n" +
+				"      \"icon\": \"book\",\n" +
+				"      \"url\": \"/screen/tutorial\"\n" +
+				"    },\n" +
+				"    {\n" +
+				"      \"name\": \"components\",\n" +
+				"      \"text\": \"Components Overview\",\n" +
+				"      \"icon\": \"block\",\n" +
+				"      \"url\": \"/screen/components\"\n" +
+				"    }\n" +
+				"]\"";
+	}
+
+	private List<ScreenResponsibility> getUiServiceResponse() {
+		ScreenResponsibility featuresScreen = new ScreenResponsibility();
+		featuresScreen.setName("features");
+		featuresScreen.setText("Features");
+		featuresScreen.setIcon("star");
+		featuresScreen.setUrl("/screen/features");
+		ScreenResponsibility apiScreen = new ScreenResponsibility();
+		apiScreen.setName("api-reference");
+		apiScreen.setText("API Reference");
+		apiScreen.setIcon("api");
+		apiScreen.setUrl("/screen/api-reference");
+		return Arrays.asList(featuresScreen, apiScreen);
+	}
+}

--- a/tesler-core/src/test/java/io/tesler/core/util/session/impl/LoginServiceImplTest.java
+++ b/tesler-core/src/test/java/io/tesler/core/util/session/impl/LoginServiceImplTest.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2020 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.util.session.impl;
+
+import io.tesler.api.data.dictionary.LOV;
+import io.tesler.api.data.dictionary.SimpleDictionary;
+import io.tesler.api.system.SystemSettings;
+import io.tesler.core.dto.LoggedUser;
+import io.tesler.core.service.ScreenResponsibilityService;
+import io.tesler.core.service.UIService;
+import io.tesler.core.service.impl.UserRoleService;
+import io.tesler.core.util.session.SessionService;
+import io.tesler.model.core.entity.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@SpringJUnitConfig({
+	LoginServiceImpl.class
+})
+public class LoginServiceImplTest {
+
+	@MockBean
+	private SessionService sessionService;
+
+	@MockBean
+	private UserRoleService userRoleService;
+
+	@MockBean
+	private SystemSettings systemSettings;
+
+	@MockBean
+	private UIService uiService;
+
+	@MockBean
+	private ScreenResponsibilityService screenResponsibilityService;
+
+	@InjectMocks
+	@Autowired
+	private LoginServiceImpl loginService;
+
+	@Test
+	public void getLoggedUser() {
+		User user = new User();
+		LOV userRole = new LOV("ADMIN");
+		when(sessionService.getSessionId()).thenReturn("id");
+		when(sessionService.getSessionUser()).thenReturn(user);
+		when(sessionService.getSessionUserRole()).thenReturn(userRole);
+		when(userRoleService.getUserRoles(user)).thenReturn(Arrays.asList(new SimpleDictionary("admin", "ADMIN")));
+		when(screenResponsibilityService.getScreens(user, userRole)).thenReturn(new ArrayList<>());
+		LoggedUser result = loginService.getLoggedUser("ADMIN");
+		assertThat(result).isNotNull();
+		// TODO: Remove when getScreens is removed from LoginServiceImpl
+		verify(screenResponsibilityService, times(1)).getScreens(user, userRole);
+	}
+}


### PR DESCRIPTION
See #68

* `LoginServiceImpl#getScreens` now calls a separate `ScreenResponsibilityService` for available screens and will be removed in next major release; deprecation warnings added.
* New `ScreenController` could be used to fetch screens instead of relying on having them in `/login` response
* Comments translation and additional JavaDocs