### PR TITLE
DTO validation should respect `ignoreBusinessErrors` flag and do not validate fields during preview call

### DIFF
--- a/tesler-core/pom.xml
+++ b/tesler-core/pom.xml
@@ -199,6 +199,16 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tesler-core/src/main/java/io/tesler/core/service/ResponseFactory.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/ResponseFactory.java
@@ -103,14 +103,14 @@ public class ResponseFactory {
 			for (String fieldName : badFields) {
 				entity.addField(fieldName, errorMessage("error.field_deserialization_error"));
 			}
-			for (ConstraintViolation<Object> violation : violations) {
-				String fieldName = null;
-				for (Path.Node node : violation.getPropertyPath()) {
-					fieldName = node.getName();
-				}
-				entity.addField(fieldName, violation.getMessage());
-			}
 			if (!ignoreBusinessErrors) {
+				for (ConstraintViolation<Object> violation : violations) {
+					String fieldName = null;
+					for (Path.Node node : violation.getPropertyPath()) {
+						fieldName = node.getName();
+					}
+					entity.addField(fieldName, violation.getMessage());
+				}
 				throw new BusinessException()
 						.setEntity(entity);
 			}
@@ -124,7 +124,7 @@ public class ResponseFactory {
 		result.setChangedFields(fields);
 		// Чтобы можно было назад возвращать
 		result.setId(bc.getId());
-		if (entity != null) {
+		if (entity != null && !entity.getFields().isEmpty()) {
 			result.setErrors(entity);
 		}
 		return result;

--- a/tesler-core/src/test/java/io/tesler/core/service/ResponseFactoryTest.java
+++ b/tesler-core/src/test/java/io/tesler/core/service/ResponseFactoryTest.java
@@ -1,0 +1,90 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2019 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.service;
+
+import io.tesler.api.data.dto.DataResponseDTO;
+import io.tesler.core.config.JacksonConfig;
+import io.tesler.core.crudma.bc.BusinessComponent;
+import io.tesler.core.dto.ValidatorsProviderImpl;
+import io.tesler.core.exception.BusinessException;
+import io.tesler.core.test.util.TestResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import io.tesler.core.dto.BusinessError.Entity;
+import java.util.LinkedHashMap;
+
+import static io.tesler.api.util.i18n.ErrorMessageSource.errorMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@SpringJUnitConfig({
+		ResponseFactory.class,
+		ValidatorsProviderImpl.class,
+		JacksonConfig.class
+})
+class ResponseFactoryTest {
+
+	@InjectMocks
+	@Autowired
+	private ResponseFactory responseFactory;
+
+	private LinkedHashMap<String, Object> map;
+	private BusinessComponent bc;
+
+
+	@BeforeEach
+	void setup() {
+		map = new LinkedHashMap<>();
+		bc = mock(BusinessComponent.class);
+	}
+
+	@Test
+	void getDTOFromMapIgnoreBusinessErrors() {
+		map.put("validatedField", "true");
+		responseFactory.getDTOFromMapIgnoreBusinessErrors(map, TestResponseDto.class, bc);
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			responseFactory.getDTOFromMap(map, TestResponseDto.class, bc);
+		});
+		assertThat(exception.getEntity().getFields().get("validatedField")).isEqualTo("Minimal length is 10");
+	}
+
+	@Test
+	void fieldDeserializationErrors() {
+		map.put("number", "aaaa");
+		DataResponseDTO result = responseFactory.getDTOFromMapIgnoreBusinessErrors(map, TestResponseDto.class, bc);
+		assertThat(result.getErrors()).isNotNull();
+		assertThat(((Entity)result.getErrors()).getFields().get("number"))
+			.isEqualTo(errorMessage("error.field_deserialization_error"));
+	}
+
+	@Test
+	void classDeserializationError() {
+		BusinessException exception = assertThrows(BusinessException.class, () -> {
+			responseFactory.getDTOFromMapIgnoreBusinessErrors(map, String.class, bc);
+		});
+		assertThat(exception.getPopup().get(0))
+				.isEqualTo(errorMessage("error.dto_deserialization_error"));
+	}
+}

--- a/tesler-core/src/test/java/io/tesler/core/test/util/TestResponseDto.java
+++ b/tesler-core/src/test/java/io/tesler/core/test/util/TestResponseDto.java
@@ -21,7 +21,19 @@
 package io.tesler.core.test.util;
 
 import io.tesler.api.data.dto.DataResponseDTO;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class TestResponseDto extends DataResponseDTO {
 
+	@Size(min = 10, message = "Minimal length is 10")
+	private String validatedField;
+
+	private Number number;
 }


### PR DESCRIPTION
https://github.com/tesler-platform/tesler/pull/62 introduced a `ignoreBusinessErrors` flag for `preview` calls of `InnerCrudmaService`
DTO validation should be treated as business error and should not fire for previews.