### PR TITLE
Include UI project when generating application from archetype

### DIFF
--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,0 +1,21 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+// Detect node npx runner
+def launcher = System.properties['os.name'].toLowerCase().contains('windows') ? "npx.cmd" : "npx"
+
+// Run create-react-app with latest @tesler-ui/cra-template-typescript
+def cmd = "${launcher} create-react-app ${request.outputDirectory}/${request.artifactId}/${request.artifactId}-ui --template @tesler-ui/cra-template-typescript"
+def proc = cmd.execute(null, new File(request.outputDirectory))
+proc.consumeProcessOutput(System.out, System.err)
+proc.waitFor()
+
+// Move UI pom from archetype to CRA-generated folder
+String pomLocation = "${request.outputDirectory}/${request.artifactId}/${request.artifactId}-ui-template"
+Path pom = Path.of("${pomLocation}/pom.xml")
+Path ui = Path.of("${request.outputDirectory}/${request.artifactId}/${request.artifactId}-ui/pom.xml")
+Files.copy(pom, ui)
+Files.delete(pom)
+Files.delete(Path.of(pomLocation))
+
+println "\nDone. Exit value: ${proc.exitValue()}"

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -139,6 +139,12 @@
         <include>pom.xml</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true">
+      <directory>__rootArtifactId__-ui-template</directory>
+      <includes>
+        <include>pom.xml</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
 </archetype-descriptor>

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>${dollar.sign}{rootArtifactId}-db</artifactId>
         </dependency>
         <dependency>
+            <groupId>${dollar.sign}{groupId}</groupId>
+            <artifactId>${dollar.sign}{rootArtifactId}-ui</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-base/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-base/pom.xml
@@ -28,14 +28,8 @@
 
     <spring.version>${spring.version}</spring.version>
     <spring-boot.version>${spring-boot.version}</spring-boot.version>
-    <liquibase.version>${liquibase.version}</liquibase.version>
-    <slf4j.version>${slf4j.version}</slf4j.version>
     <tesler.version>${version}</tesler.version>
-
-    <junit.jupiter.version>${junit.jupiter.version}</junit.jupiter.version>
-    <junit.platform.version>${junit.platform.version}</junit.platform.version>
     <surefire.version>${surefire.version}</surefire.version>
-    <mockito.version>${mockito.version}</mockito.version>
 
     <!-- build settings -->
     <spring.active.profiles/>
@@ -81,9 +75,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-framework-bom</artifactId>
-        <version>${dollar.sign}{spring.version}</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${dollar.sign}{spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -127,26 +121,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${dollar.sign}{slf4j.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.liquibase</groupId>
-        <artifactId>liquibase-core</artifactId>
-        <version>${dollar.sign}{liquibase.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.pf4j</groupId>
         <artifactId>pf4j</artifactId>
         <version>2.6.0</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok</artifactId>
-        <version>1.18.10</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -173,41 +153,11 @@
         <version>1.3.2</version>
       </dependency>
 
-
       <!-- Test -->
 
       <dependency>
         <groupId>commons-dbcp</groupId>
         <artifactId>commons-dbcp</artifactId>
-        <version>1.4</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${dollar.sign}{junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${dollar.sign}{junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-launcher</artifactId>
-        <version>${dollar.sign}{junit.platform.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${dollar.sign}{mockito.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -222,13 +172,6 @@
             <artifactId>junit</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>${dollar.sign}{spring.version}</version>
-        <scope>test</scope>
       </dependency>
 
     </dependencies>
@@ -254,7 +197,6 @@
         <plugin>
           <groupId>org.liquibase</groupId>
           <artifactId>liquibase-maven-plugin</artifactId>
-          <version>${dollar.sign}{liquibase.version}</version>
           <dependencies>
             <dependency>
               <groupId>io.tesler</groupId>

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-bom/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-bom/pom.xml
@@ -47,6 +47,11 @@
         <version>${dollar.sign}{version}</version>
         <classifier>tests</classifier>
       </dependency>
+      <dependency>
+        <groupId>${dollar.sign}{groupId}</groupId>
+        <artifactId>${dollar.sign}{rootArtifactId}-ui</artifactId>
+        <version>${dollar.sign}{version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-db/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-db/pom.xml
@@ -22,6 +22,11 @@
       <groupId>io.tesler</groupId>
       <artifactId>tesler-liquibase</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.8</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -29,6 +34,7 @@
       <plugin>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-maven-plugin</artifactId>
+        <version>3.6.3</version>
         <configuration>
           <skip>false</skip>
           <driver>${dollar.sign}{jdbc.driver}</driver>

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-ui-template/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-ui-template/pom.xml
@@ -1,0 +1,99 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>${dollar.sign}{rootArtifactId}-ui</artifactId>
+  <packaging>jar</packaging>
+  <version>${dollar.sign}{version}</version>
+  <name>${dollar.sign}{appUpperCaseName} - UI</name>
+
+  <parent>
+    <groupId>${dollar.sign}{groupId}</groupId>
+    <artifactId>${dollar.sign}{rootArtifactId}-base</artifactId>
+    <version>${dollar.sign}{version}</version>
+    <relativePath>../${dollar.sign}{rootArtifactId}-base/pom.xml</relativePath>
+  </parent>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>node_modules</directory>
+            </fileset>
+            <fileset>
+              <directory>build</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>exec-npm-install</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <workingDirectory>${dollar.sign}{project.basedir}</workingDirectory>
+              <executable>npm</executable>
+              <arguments>
+                <argument>install</argument>
+              </arguments>
+            </configuration>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>exec-npm-run-build</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <workingDirectory>${dollar.sign}{project.basedir}</workingDirectory>
+              <executable>npm</executable>
+              <arguments>
+                <argument>run</argument>
+                <argument>build</argument>
+              </arguments>
+            </configuration>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ui-resources</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${dollar.sign}{project.build.outputDirectory}/ui</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${dollar.sign}{project.basedir}/build</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+
+</project>

--- a/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/pom.xml
@@ -19,6 +19,12 @@
         <module>${dollar.sign}{rootArtifactId}-it</module>
       </modules>
     </profile>
+    <profile>
+      <id>UI</id>
+      <modules>
+        <module>${dollar.sign}{rootArtifactId}-ui</module>
+      </modules>
+    </profile>
   </profiles>
 
   <modules>


### PR DESCRIPTION
Maven archetype now includes `${artifactId}-ui-template` module with .pom file for building UI project.

When regular archetype routine is complete a groovy [post-generation script](https://maven.apache.org/archetype/maven-archetype-plugin/advanced-usage.html) will fire to generate [create-react-application](https://github.com/facebook/create-react-app)  UI project from [@tesler-ui/cra-template-typescript](https://www.npmjs.com/package/@tesler-ui/cra-template-typescript) template.

.pom file then will be moved from `${artifactId}-ui-template` to `${artifactId}-ui` and `${artifactId}-ui-template` will be deleted.
(rename procedure reasoned by neither CRA nor maven willing to generate application into existing folder; alternative solution is to have a nested structure like `${artifactId}-ui/pom.xml` and `${artifactId}-ui/ui/`)

Usage example:
* fetch the branch

* build from project root:
```sh
mvn install
```
* generate application from the future project location
```sh
mvn archetype:generate -DarchetypeGroupId=io.tesler -DarchetypeArtifactId=tesler-base-archetype -DarchetypeVersion=3.0.0-SNAPSHOT
```
Specify groupId and artifactId when asked

## Fixes

* Archetypes are broken from 2.1.1 onward due to #54 removed [liquibase.version](https://github.com/tesler-platform/tesler/commit/f91fa767736e23dd059ea83176353e4ec8d7ae93#diff-b8cf51724126a0cdb296b55ff76708ddL41), [junit.jupiter.version](https://github.com/tesler-platform/tesler/commit/f91fa767736e23dd059ea83176353e4ec8d7ae93#diff-b8cf51724126a0cdb296b55ff76708ddL37) and [junit.platform.version](https://github.com/tesler-platform/tesler/commit/f91fa767736e23dd059ea83176353e4ec8d7ae93#diff-b8cf51724126a0cdb296b55ff76708ddL38
) properties which are still used by [`__rootArtifactId__-base module`](https://github.com/tesler-platform/tesler/blob/651249416cc575b661987c5236f1b3db084eedf7/tesler-archetypes/tesler-base-archetype/src/main/resources/archetype-resources/__rootArtifactId__-base/pom.xml#L31).  

This lead to a result .pom having unresolved recursive `<junit.jupiter.version>${junit.jupiter.version}</junit.jupiter.version>` properties that will break maven parsing ([MNG-6921](https://issues.apache.org/jira/browse/MNG-6921)).

The fix is to replace separate dependencies and properties by `spring-boot-dependencies` dependency as in main project.

* include postgresql driver