### PR TITLE
Allow custom invokes to read raw input data when invoked without specific record

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/crudma/impl/AbstractResponseService.java
+++ b/tesler-core/src/main/java/io/tesler/core/crudma/impl/AbstractResponseService.java
@@ -251,7 +251,7 @@ public abstract class AbstractResponseService<T extends DataResponseDTO, E exten
 				record = doGetOne(bc);
 			}
 		}
-		return action.invoke(bc, record);
+		return action.invoke(bc, Optional.ofNullable(record).orElse((T)data));
 	}
 
 


### PR DESCRIPTION
At the moment `AbstractResponseService#invokeAction` implicitly suggests that custom actions could only be invoked for existing records:
https://github.com/tesler-platform/tesler/blob/651249416cc575b661987c5236f1b3db084eedf7/tesler-core/src/main/java/io/tesler/core/crudma/impl/AbstractResponseService.java#L229-L254

So if custom action called without providing a cursor the data from the request will not be passed into the service.   
This doesn't seem right as there are at least valid two scenarios I can think of for invoking custom action without pre-existing record:
1) Creating record with custom action (I suspect that missing access to the request data was the original reason behind why we had to introduce `action roles` concept). We don't have record id yet but we can receive input data and implement creation logic in service
2) Bulk changes for items: it can be easily implemented with by providing affected records ids and changeset to be processed in service's custom action, if latter had the access to raw input.

So basically the suggestion is to allow the service to handle custom actions input in any way needed.