### PR TITLE
Feature/cluster support with spring session

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
@@ -39,7 +39,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.annotation.RequestScope;
-import org.springframework.web.context.annotation.SessionScope;
 import org.springframework.web.context.request.RequestContextHolder;
 
 

--- a/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
@@ -51,6 +51,8 @@ public class CacheConfig extends CachingConfigurerSupport {
 
 	public static final String WORKFLOW_CACHE = "workflow";
 
+	public static final String USER_CACHE = "userCache";
+
 	public static final String REQUEST_CACHE = "requestCache";
 
 	public static final String LINKED_DICTIONARY_RULES = "linkedDictionaryRules";
@@ -60,6 +62,11 @@ public class CacheConfig extends CachingConfigurerSupport {
 	public static final String UI_CACHE = "widgetcache";
 
 	private final ApplicationContext applicationContext;
+
+	@Bean(name = USER_CACHE)
+	public Cache sessionCache() {
+		return new ConcurrentMapCache(USER_CACHE);
+	}
 
 	@Bean(name = REQUEST_CACHE)
 	@RequestScope
@@ -85,7 +92,7 @@ public class CacheConfig extends CachingConfigurerSupport {
 				SPECIFICATION_CACHE,
 				UI_CACHE
 		));
-		result.add(buildRequestAwareCacheManager(REQUEST_CACHE));
+		result.add(buildRequestAwareCacheManager(USER_CACHE, REQUEST_CACHE));
 		return result;
 	}
 

--- a/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
@@ -52,8 +52,6 @@ public class CacheConfig extends CachingConfigurerSupport {
 
 	public static final String WORKFLOW_CACHE = "workflow";
 
-	public static final String SESSION_CACHE = "sessionCache";
-
 	public static final String REQUEST_CACHE = "requestCache";
 
 	public static final String LINKED_DICTIONARY_RULES = "linkedDictionaryRules";
@@ -63,12 +61,6 @@ public class CacheConfig extends CachingConfigurerSupport {
 	public static final String UI_CACHE = "widgetcache";
 
 	private final ApplicationContext applicationContext;
-
-	@Bean(name = SESSION_CACHE)
-	@SessionScope
-	public Cache sessionCache() {
-		return new ConcurrentMapCache(SESSION_CACHE);
-	}
 
 	@Bean(name = REQUEST_CACHE)
 	@RequestScope
@@ -94,7 +86,7 @@ public class CacheConfig extends CachingConfigurerSupport {
 				SPECIFICATION_CACHE,
 				UI_CACHE
 		));
-		result.add(buildRequestAwareCacheManager(SESSION_CACHE, REQUEST_CACHE));
+		result.add(buildRequestAwareCacheManager(REQUEST_CACHE));
 		return result;
 	}
 

--- a/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/CacheConfig.java
@@ -64,7 +64,7 @@ public class CacheConfig extends CachingConfigurerSupport {
 	private final ApplicationContext applicationContext;
 
 	@Bean(name = USER_CACHE)
-	public Cache sessionCache() {
+	public Cache userCache() {
 		return new ConcurrentMapCache(USER_CACHE);
 	}
 

--- a/tesler-core/src/main/java/io/tesler/core/util/session/impl/SessionServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/util/session/impl/SessionServiceImpl.java
@@ -52,7 +52,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.web.authentication.session.SessionAuthenticationException;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;

--- a/tesler-core/src/main/java/io/tesler/core/util/session/impl/SessionServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/util/session/impl/SessionServiceImpl.java
@@ -79,8 +79,6 @@ public class SessionServiceImpl implements SessionService {
 
 	private final BcHierarchyAware bcHierarchyAware;
 
-	private final SessionCache sessionCache;
-
 	private final GroupService groupService;
 
 	// если у нас транзакции нет, то здесь будут происходить
@@ -219,7 +217,7 @@ public class SessionServiceImpl implements SessionService {
 
 	@Override
 	public Map<String, Boolean> getResponsibilities() {
-		return sessionCache.getResponsibilities(getSessionUser(), getSessionUserRole());
+		return uiService.getResponsibilities(getSessionUser(),getSessionUserRole());
 	}
 
 	@Override
@@ -269,7 +267,7 @@ public class SessionServiceImpl implements SessionService {
 
 	@Override
 	public List<String> getViews(final String screenName) {
-		return sessionCache.getViews(screenName, getSessionUser(), getSessionUserRole());
+		return uiService.getViews(screenName, getSessionUser(), getSessionUserRole());
 	}
 
 	@Cacheable(cacheNames = {CacheConfig.REQUEST_CACHE}, key = "#root.methodName")
@@ -277,36 +275,4 @@ public class SessionServiceImpl implements SessionService {
 	public Set<Long> getAllUserGroups() {
 		return groupService.getUserAllGroups(getSessionUser());
 	}
-
-	@Component
-	@RequiredArgsConstructor
-	public static class SessionCache {
-
-		private final UIService uiService;
-
-		@Cacheable(
-				cacheNames = {CacheConfig.SESSION_CACHE},
-				key = "{#root.methodName, #user.id, #userRole}"
-		)
-		public Map<String, Boolean> getResponsibilities(final User user, final LOV userRole) {
-			return uiService.getResponsibilities(
-					user,
-					userRole
-			);
-		}
-
-		@Cacheable(
-				cacheNames = {CacheConfig.SESSION_CACHE},
-				key = "{#root.methodName, #screenName, #user.id, #userRole}"
-		)
-		public List<String> getViews(final String screenName, final User user, final LOV userRole) {
-			return uiService.getViews(
-					screenName,
-					user,
-					userRole
-			);
-		}
-
-	}
-
 }

--- a/tesler-core/src/main/java/io/tesler/core/util/session/impl/SessionServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/util/session/impl/SessionServiceImpl.java
@@ -79,7 +79,7 @@ public class SessionServiceImpl implements SessionService {
 
 	private final BcHierarchyAware bcHierarchyAware;
 
-	private final SessionCache sessionCache;
+	private final UserCache userCache;
 
 	private final GroupService groupService;
 
@@ -219,7 +219,7 @@ public class SessionServiceImpl implements SessionService {
 
 	@Override
 	public Map<String, Boolean> getResponsibilities() {
-		return sessionCache.getResponsibilities(getSessionUser(), getSessionUserRole());
+		return userCache.getResponsibilities(getSessionUser(), getSessionUserRole());
 	}
 
 	@Override
@@ -269,7 +269,7 @@ public class SessionServiceImpl implements SessionService {
 
 	@Override
 	public List<String> getViews(final String screenName) {
-		return sessionCache.getViews(screenName, getSessionUser(), getSessionUserRole());
+		return userCache.getViews(screenName, getSessionUser(), getSessionUserRole());
 	}
 
 	@Cacheable(cacheNames = {CacheConfig.REQUEST_CACHE}, key = "#root.methodName")
@@ -280,7 +280,7 @@ public class SessionServiceImpl implements SessionService {
 
 	@Component
 	@RequiredArgsConstructor
-	public static class SessionCache {
+	public static class UserCache {
 
 		private final UIService uiService;
 


### PR DESCRIPTION
Cluster support with spring session added.

- Before this MR tesler platform in cluster mode produced error (see 2 node [scenario](https://youtu.be/iHdriuhoEu8))

- After this MR one can choose any spring-session provider [(jdbc, redis and so on)](https://spring.io/projects/spring-session) and work in cluster mode (see [scenario](https://youtu.be/2K2jZy6iGpY) for [tesler-doc](https://github.com/tesler-platform/tesler-doc/pull/22) exmaple application. Includes configuring spring-session-jdbc and working with 2 nodes)