### PR TITLE
A stack trace is put to an error.

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/controller/GlobalExceptionHandler.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/GlobalExceptionHandler.java
@@ -57,17 +57,12 @@ public class GlobalExceptionHandler {
 	private ExceptionHandlerSettings settings;
 
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<String> exception(Exception e) {
+	@ResponseStatus(value = INTERNAL_SERVER_ERROR)
+	@ResponseBody
+	public ErrorResponseDTO exception(Exception e) {
 		UUID uuid = UUID.randomUUID();
 		log.error(buildLogMessage(e, uuid), e);
-		return buildResponse(buildResponseBody(e, uuid), INTERNAL_SERVER_ERROR);
-	}
-
-	@ExceptionHandler(ServerException.class)
-	public ResponseEntity<String> serverException(ServerException e) {
-		UUID uuid = UUID.randomUUID();
-		log.error(buildLogMessage(e, uuid), e);
-		return buildResponse(buildResponseBody(e, uuid), INTERNAL_SERVER_ERROR);
+		return new ErrorResponseDTO(buildResponseBody(e, uuid));
 	}
 
 	@ExceptionHandler(ClientException.class)
@@ -108,7 +103,7 @@ public class GlobalExceptionHandler {
 
 	private ResponseEntity<String> buildResponse(String message, HttpStatus status) {
 		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.valueOf("text/plain;charset=UTF-8"));
+		headers.setContentType(MediaType.valueOf("application/json;charset=UTF-8"));
 		return new ResponseEntity<>(message, headers, status);
 	}
 

--- a/tesler-core/src/main/java/io/tesler/core/dto/ErrorResponseDTO.java
+++ b/tesler-core/src/main/java/io/tesler/core/dto/ErrorResponseDTO.java
@@ -34,7 +34,13 @@ public final class ErrorResponseDTO {
 
 	private Object data;
 
-	private final BusinessError error;
+	private String errorMessage;
+
+	private BusinessError error;
+
+	public ErrorResponseDTO(String e) {
+		this.errorMessage = e;
+	}
 
 	public ErrorResponseDTO(BusinessException e) {
 		this.error = new BusinessError(e.getPopup(), e.getEntity(), null, e.getPostActions());

--- a/tesler-core/src/test/java/io/tesler/core/controller/GlobalExceptionHandlerTest.java
+++ b/tesler-core/src/test/java/io/tesler/core/controller/GlobalExceptionHandlerTest.java
@@ -23,7 +23,6 @@ package io.tesler.core.controller;
 import static io.tesler.api.util.i18n.ErrorMessageSource.errorMessage;
 import static org.mockito.Mockito.when;
 
-import io.tesler.api.exception.ServerException;
 import io.tesler.core.dto.ErrorResponseDTO;
 import io.tesler.core.exception.BusinessException;
 import io.tesler.core.exception.BusinessIntermediateException;
@@ -61,14 +60,8 @@ class GlobalExceptionHandlerTest {
 
 	@Test
 	void testException() {
-		ResponseEntity<String> result = globalExceptionHandler.exception(new Exception("something is wrong"));
-		Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());
-	}
-
-	@Test
-	void testServerException() {
-		ResponseEntity<String> result = globalExceptionHandler.serverException(new ServerException("message", null));
-		Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());
+		ErrorResponseDTO result = globalExceptionHandler.exception(new Exception("something is wrong"));
+		Assertions.assertTrue(result.getErrorMessage().contains("something is wrong"));
 	}
 
 	@Test


### PR DESCRIPTION
`serverException` method is deleted as duplicate of `exception` method.