### PR TITLE
count operation should skip order by

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/crudma/impl/AbstractResponseService.java
+++ b/tesler-core/src/main/java/io/tesler/core/crudma/impl/AbstractResponseService.java
@@ -64,6 +64,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityGraph;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.metamodel.SingularAttribute;
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -323,7 +324,11 @@ public abstract class AbstractResponseService<T extends DataResponseDTO, E exten
 		return dao.getCount(
 				typeOfEntity,
 				typeOfDTO,
-				specificationBuilder.buildBcSpecification(bc),
+				(root, cq, cb) -> {
+					Predicate pr = specificationBuilder.buildBcSpecification(bc).toPredicate(root, cq, cb);
+					cq.orderBy();
+					return pr;
+				},
 				bc.getParameters()
 		);
 	}


### PR DESCRIPTION
One can use order by with subquery, that correctly requests data, but count request crashes

Data request SQL:
```sql
select sao0_.ID
from public.sao sao0_
         cross join public.sao sao1_
where sao0_.ID = sao1_.ID
order by (select MAX(GREATEST(sao.id, sa.id, sc.id, sr.id))
          from sao sao
                   left join sa on sa.id = sao.sma_id
                   left join sc on sa.id = sc.sma_id
                   left join sr on sc.id = sr.sc_id
          where sao.id = sao1_.id
          group by sao.id) desc
limit ?
```

count request produces error`[42803] ERROR: subquery uses ungrouped column "sao1_.id" from outer query`:
```sql
select count(sao0_.ID)
from public.sao sao0_
         cross join public.sao sao1_
where sao0_.ID = sao1_.ID
order by (select MAX(GREATEST(sao.id, sa.id, sc.id, sr.id))
          from sao sao
                   left join sa on sa.id = sao.sma_id
                   left join sc on sa.id = sc.sma_id
                   left join sr on sc.id = sr.sc_id
          where sao.id = sao1_.id
          group by sao.id) desc
```
fixed in this MR count succedes. SQL:

```sql 
select count(sao0_.ID)
from public.sao sao0_
         cross join public.sao sao1_
where sao0_.ID = sao1_.ID
```

