### PR TITLE
hibernate bytecode enhance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.tesler</groupId>
   <artifactId>tesler</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler</name>
   <description>Java framework designed for creating Enterprise Rich Web Applications</description>
   <inceptionYear>2018</inceptionYear>
@@ -36,7 +36,7 @@
     <connection>scm:git:git@github.com:tesler-platformtesler.git</connection>
     <developerConnection>scm:git:git@github.com:tesler-platform/tesler.git</developerConnection>
     <url>https://github.com/tesler-platform/tesler</url>
-    <tag>tesler-3.0.0.M7</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>
@@ -50,7 +50,14 @@
     </repository>
   </distributionManagement>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.7.RELEASE</version>
+  </parent>
+
   <properties>
+    <hibernate.version>5.4.13.Final</hibernate.version>
     <checktyle.config>/tesler-base/src/main/resources/checkstyle-checker.xml</checktyle.config>
     <flatten.mode>oss</flatten.mode>
     <skip.license>false</skip.license>

--- a/tesler-all/pom.xml
+++ b/tesler-all/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tesler-all</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <name>IO Tesler - All</name>
 
     <parent>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-base</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
         <relativePath>../tesler-base/pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
                 <groupId>io.tesler</groupId>
                 <artifactId>tesler-bom</artifactId>
                 <type>import</type>
-                <version>3.0.0.M7</version>
+                <version>3.0.0.M7.3-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tesler-api/pom.xml
+++ b/tesler-api/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-api</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - API</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-archetypes/pom.xml
+++ b/tesler-archetypes/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-archetypes</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Archetypes</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-archetypes/tesler-base-archetype/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-base-archetype</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Base Archetype</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-archetypes</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-base/pom.xml
+++ b/tesler-base/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-base</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Base</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-bom</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-bom/pom.xml</relativePath>
   </parent>
 
@@ -76,15 +76,7 @@
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-bom</artifactId>
-        <version>3.0.0.M7</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.1.7.RELEASE</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tesler-bom/pom.xml
+++ b/tesler-bom/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-bom</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Bill of Materials</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,100 +19,100 @@
         <groupId>io.tesler</groupId>
         <artifactId>tesler-bom</artifactId>
         <type>pom</type>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-constgen</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-api</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-model-core</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-model-ui</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-core</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-crudma</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-testing</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-all</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-crudma</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-cache</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-model</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-engine</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-all</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-crudma</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-model</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-liquibase</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-plugin</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-all</artifactId>
         <type>pom</type>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tesler-constgen/pom.xml
+++ b/tesler-constgen/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-constgen</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - DTO Constant Generator</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-core/pom.xml
+++ b/tesler-core/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-core</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Core</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-core/src/main/java/io/tesler/core/dao/impl/notifications/NotificationDAOImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/dao/impl/notifications/NotificationDAOImpl.java
@@ -77,10 +77,10 @@ public class NotificationDAOImpl implements NotificationDAO {
 		return (root, cq, cb) -> {
 			List<Predicate> predicates = new ArrayList<>();
 			predicates.add(cb.equal(root.get(Notification_.recipientId), recipientId));
-			predicates.add(cb.equal(root.get(Notification_.push), 1));
+			predicates.add(cb.equal(root.get(Notification_.pushBit), 1));
 			if (unread) {
 				predicates.add(
-						cb.equal(root.get(Notification_.read), 0)
+						cb.equal(root.get(Notification_.readBit), 0)
 				);
 			}
 			if (offset != null) {
@@ -101,7 +101,7 @@ public class NotificationDAOImpl implements NotificationDAO {
 		for (List<NotificationDeferredResult> chunk : Lists.partition(recipients, 500)) {
 			notifications.addAll(jpaDao.getList(
 					Notification.class, (root, cq, cb) -> cb.and(
-							cb.equal(root.get(Notification_.push), 1),
+							cb.equal(root.get(Notification_.pushBit), 1),
 							cb.or(chunk.stream().map(e -> {
 										List<Predicate> predicates = new ArrayList<>();
 										predicates.add(cb.equal(root.get(Notification_.recipientId), e.getRecipientId()));

--- a/tesler-crudma/pom.xml
+++ b/tesler-crudma/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-crudma</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Source</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/pom.xml
+++ b/tesler-dictionary-links/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Plugins</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-all/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-all/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-all</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary All</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-crudma/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-crudma/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-crudma</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Links Implementation</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-engine/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-engine/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-engine</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Links Engine</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-model/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-model/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-model</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Links Model</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/pom.xml
+++ b/tesler-dictionary/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-all/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-all/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-all</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary All</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-cache/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-cache/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-cache</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Cache</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-crudma/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-crudma/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-crudma</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Crudma</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-model/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-model/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-model</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Model</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,5 +20,26 @@
       <artifactId>tesler-model-core</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.hibernate.orm.tooling</groupId>
+        <artifactId>hibernate-enhance-maven-plugin</artifactId>
+        <version>${hibernate.version}</version>
+        <executions>
+          <execution>
+            <configuration>
+              <failOnError>true</failOnError>
+              <enableDirtyTracking>true</enableDirtyTracking>
+              <enableLazyInitialization>true</enableLazyInitialization>
+            </configuration>
+            <goals>
+              <goal>enhance</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/tesler-liquibase/pom.xml
+++ b/tesler-liquibase/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-liquibase</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Liquibase</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-model/pom.xml
+++ b/tesler-model/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tesler-model</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <name>IO Tesler - Models</name>
 
     <parent>
         <groupId>io.tesler</groupId>
         <artifactId>tesler</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tesler-model/tesler-model-base/pom.xml
+++ b/tesler-model/tesler-model-base/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-model-base</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Model Base</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-model/tesler-model-core/pom.xml
+++ b/tesler-model/tesler-model-core/pom.xml
@@ -3,14 +3,34 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-model-core</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Model Core</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-model-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-model-base/pom.xml</relativePath>
   </parent>
-  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.hibernate.orm.tooling</groupId>
+        <artifactId>hibernate-enhance-maven-plugin</artifactId>
+        <version>${hibernate.version}</version>
+        <executions>
+          <execution>
+            <configuration>
+              <failOnError>true</failOnError>
+              <enableDirtyTracking>true</enableDirtyTracking>
+              <enableLazyInitialization>true</enableLazyInitialization>
+            </configuration>
+            <goals>
+              <goal>enhance</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/notifications/Notification.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/notifications/Notification.java
@@ -23,12 +23,9 @@ package io.tesler.model.core.entity.notifications;
 
 import io.tesler.api.data.dictionary.LOV;
 import io.tesler.model.core.entity.BaseEntity;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Lob;
-import javax.persistence.PrePersist;
-import javax.persistence.PreUpdate;
-import javax.persistence.Table;
+
+import javax.persistence.*;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,10 +61,10 @@ public class Notification extends BaseEntity {
 	private String uiMessage;
 
 	@Formula("BITAND(DELIVERY_STATUS, 1)")
-	private Integer read;
+	private Integer readBit;
 
 	@Formula("BITAND(DELIVERY_TYPE, 1)")
-	private Integer push;
+	private Integer pushBit;
 
 	@Column(name = "URL")
 	private String url;
@@ -94,12 +91,14 @@ public class Notification extends BaseEntity {
 		this.uiSubject = StringUtils.truncate(this.uiSubject, 1500);
 	}
 
+	@Transient
 	public boolean isRead() {
-		return read == 1;
+		return readBit == 1;
 	}
 
+	@Transient
 	public boolean isPush() {
-		return push == 1;
+		return pushBit == 1;
 	}
 
 }

--- a/tesler-model/tesler-model-ui/pom.xml
+++ b/tesler-model/tesler-model-ui/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-model-ui</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Model UI</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-model-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-model-base/pom.xml</relativePath>
   </parent>
 
@@ -19,6 +19,26 @@
       <artifactId>tesler-model-core</artifactId>
     </dependency>
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.hibernate.orm.tooling</groupId>
+        <artifactId>hibernate-enhance-maven-plugin</artifactId>
+        <version>${hibernate.version}</version>
+        <executions>
+          <execution>
+            <configuration>
+              <failOnError>true</failOnError>
+              <enableDirtyTracking>true</enableDirtyTracking>
+              <enableLazyInitialization>true</enableLazyInitialization>
+            </configuration>
+            <goals>
+              <goal>enhance</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/tesler-plugin/pom.xml
+++ b/tesler-plugin/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tesler-plugin</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <name>IO Tesler - Plugin</name>
 
     <parent>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-base</artifactId>
-        <version>3.0.0.M7</version>
+        <version>3.0.0.M7.3-SNAPSHOT</version>
         <relativePath>../tesler-base/pom.xml</relativePath>
     </parent>
 

--- a/tesler-testing/pom.xml
+++ b/tesler-testing/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-testing</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M7</version>
+  <version>3.0.0.M7.3-SNAPSHOT</version>
   <name>IO Tesler - Testing</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M7</version>
+    <version>3.0.0.M7.3-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
hibernate bytecode enhance added (to optimize performance in projects with large hibernate 1st level cache. See https://vladmihalcea.com/how-to-enable-bytecode-enhancement-dirty-checking-in-hibernate/, https://docs.jboss.org/hibernate/orm/5.4/topical/html_single/bytecode/BytecodeEnhancement.html)

hibernate version updated to 5.4.13.Final