### PR TITLE
lazy initialized fields support in JpaDao and so on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.tesler</groupId>
   <artifactId>tesler</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler</name>
   <description>Java framework designed for creating Enterprise Rich Web Applications</description>
   <inceptionYear>2018</inceptionYear>

--- a/tesler-all/pom.xml
+++ b/tesler-all/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tesler-all</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <name>IO Tesler - All</name>
 
     <parent>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-base</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
         <relativePath>../tesler-base/pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
                 <groupId>io.tesler</groupId>
                 <artifactId>tesler-bom</artifactId>
                 <type>import</type>
-                <version>3.0.0.M8.0-SNAPSHOT</version>
+                <version>3.0.0.M8.2-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tesler-api/pom.xml
+++ b/tesler-api/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-api</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - API</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-archetypes/pom.xml
+++ b/tesler-archetypes/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-archetypes</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Archetypes</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-archetypes/tesler-base-archetype/pom.xml
+++ b/tesler-archetypes/tesler-base-archetype/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-base-archetype</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Base Archetype</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-archetypes</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-base/pom.xml
+++ b/tesler-base/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-base</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Base</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-bom</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-bom/pom.xml</relativePath>
   </parent>
 
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-bom</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tesler-bom/pom.xml
+++ b/tesler-bom/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-bom</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Bill of Materials</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,100 +19,100 @@
         <groupId>io.tesler</groupId>
         <artifactId>tesler-bom</artifactId>
         <type>pom</type>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-constgen</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-api</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-model-core</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-model-ui</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-core</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-crudma</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-testing</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-all</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-crudma</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-cache</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-model</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-engine</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-all</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-crudma</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-dictionary-links-model</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-liquibase</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-plugin</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-all</artifactId>
         <type>pom</type>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tesler-constgen/pom.xml
+++ b/tesler-constgen/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-constgen</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - DTO Constant Generator</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-core/pom.xml
+++ b/tesler-core/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-core</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Core</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-core/src/main/java/io/tesler/core/exception/InnerBcException.java
+++ b/tesler-core/src/main/java/io/tesler/core/exception/InnerBcException.java
@@ -24,6 +24,7 @@ import io.tesler.core.dto.BusinessError.Entity;
 import io.tesler.model.core.entity.BaseEntity;
 import java.lang.reflect.Field;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 
 @Slf4j
 public class InnerBcException extends BusinessException {
@@ -33,7 +34,7 @@ public class InnerBcException extends BusinessException {
 		Entity errorEntity;
 		if (entity != null) {
 			errorEntity = new Entity("InnerBusinessComponent", entity.getId().toString());
-			for (Field field : entity.getClass().getFields()) {
+			for (Field field : Hibernate.getClass(entity).getFields()) {
 				errorEntity.addField(field.getName(), field.getType().getSimpleName());
 			}
 		} else {

--- a/tesler-crudma/pom.xml
+++ b/tesler-crudma/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-crudma</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Source</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/pom.xml
+++ b/tesler-dictionary-links/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Plugins</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-all/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-all/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-all</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary All</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-crudma/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-crudma/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-crudma</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Links Implementation</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-engine/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-engine/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-engine</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Links Engine</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary-links/tesler-dictionary-links-model/pom.xml
+++ b/tesler-dictionary-links/tesler-dictionary-links-model/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-links-model</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Links Model</name>
 
   <parent>
     <artifactId>tesler-dictionary-links</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/pom.xml
+++ b/tesler-dictionary/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-all/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-all/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-all</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary All</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-cache/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-cache/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-cache</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Cache</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-crudma/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-crudma/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-crudma</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Crudma</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-dictionary/tesler-dictionary-model/pom.xml
+++ b/tesler-dictionary/tesler-dictionary-model/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-dictionary-model</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Dictionary Model</name>
 
   <parent>
     <artifactId>tesler-dictionary</artifactId>
     <groupId>io.tesler</groupId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tesler-liquibase/pom.xml
+++ b/tesler-liquibase/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-liquibase</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Liquibase</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-model/pom.xml
+++ b/tesler-model/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tesler-model</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <name>IO Tesler - Models</name>
 
     <parent>
         <groupId>io.tesler</groupId>
         <artifactId>tesler</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tesler-model/tesler-model-base/pom.xml
+++ b/tesler-model/tesler-model-base/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-model-base</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Model Base</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../../tesler-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-model/tesler-model-core/pom.xml
+++ b/tesler-model/tesler-model-core/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-model-core</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Model Core</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-model-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-model-base/pom.xml</relativePath>
   </parent>
   <build>

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/dao/impl/JpaDaoImpl.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/dao/impl/JpaDaoImpl.java
@@ -66,6 +66,7 @@ import javax.persistence.metamodel.ManagedType;
 import javax.persistence.metamodel.SingularAttribute;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
@@ -217,7 +218,7 @@ public class JpaDaoImpl implements JpaDao {
 
 	@Override
 	public void refresh(AbstractEntity o) {
-		EntityManager supportedEntityManager = getSupportedEntityManager(o.getClass().getName());
+		EntityManager supportedEntityManager = getSupportedEntityManager(Hibernate.getClass(o).getName());
 		if (supportedEntityManager.contains(o)) {
 			supportedEntityManager.unwrap(Session.class).refresh(o);
 		}
@@ -225,18 +226,18 @@ public class JpaDaoImpl implements JpaDao {
 
 	@Override
 	public <T> T save(Object entity) {
-		return (T) getSupportedEntityManager(entity.getClass().getName()).unwrap(Session.class).save(entity);
+		return (T) getSupportedEntityManager(Hibernate.getClass(entity).getName()).unwrap(Session.class).save(entity);
 	}
 
 	@Override
 	public <T extends BaseEntity> T evict(T o) {
-		getSupportedEntityManager(o.getClass().getName()).unwrap(Session.class).evict(o);
+		getSupportedEntityManager(Hibernate.getClass(o).getName()).unwrap(Session.class).evict(o);
 		return o;
 	}
 
 	@Override
 	public void delete(AbstractEntity o) {
-		EntityManager supportedEntityManager = getSupportedEntityManager(o.getClass().getName());
+		EntityManager supportedEntityManager = getSupportedEntityManager(Hibernate.getClass(o).getName());
 		supportedEntityManager.unwrap(Session.class).delete(supportedEntityManager.merge(o));
 	}
 
@@ -281,12 +282,12 @@ public class JpaDaoImpl implements JpaDao {
 
 	@Override
 	public void saveWithCompositeKey(EmbeddedKeyable o) {
-		getSupportedEntityManager(o.getClass().getName()).unwrap(Session.class).save(o);
+		getSupportedEntityManager(Hibernate.getClass(o).getName()).unwrap(Session.class).save(o);
 	}
 
 	@Override
 	public void deleteWithCompositeKey(EmbeddedKeyable o) {
-		getSupportedEntityManager(o.getClass().getName()).unwrap(Session.class).delete(o);
+		getSupportedEntityManager(Hibernate.getClass(o).getName()).unwrap(Session.class).delete(o);
 	}
 
 	@Override
@@ -304,7 +305,7 @@ public class JpaDaoImpl implements JpaDao {
 		}
 		Map<String, Object> options = new HashMap<>();
 		options.put(AvailableSettings.LOCK_TIMEOUT, timeout);
-		getSupportedEntityManager(entity.getClass().getName()).lock(entity, lockMode, options);
+		getSupportedEntityManager(Hibernate.getClass(entity).getName()).lock(entity, lockMode, options);
 	}
 
 	@Override
@@ -314,8 +315,8 @@ public class JpaDaoImpl implements JpaDao {
 		}
 		Map<String, Object> options = new HashMap<>();
 		options.put(AvailableSettings.LOCK_TIMEOUT, timeout);
-		getSupportedEntityManager(entity.getClass().getName()).lock(entity, LockModeType.PESSIMISTIC_READ, options);
-		getSupportedEntityManager(entity.getClass().getName()).refresh(entity);
+		getSupportedEntityManager(Hibernate.getClass(entity).getName()).lock(entity, LockModeType.PESSIMISTIC_READ, options);
+		getSupportedEntityManager(Hibernate.getClass(entity).getName()).refresh(entity);
 	}
 
 	@Override

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/listeners/hbn/change/ChangeInterceptor.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/listeners/hbn/change/ChangeInterceptor.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.event.spi.AbstractEvent;
@@ -89,7 +90,7 @@ public class ChangeInterceptor implements ApplicationListener<EntitySerializatio
 		}
 
 		BaseEntity entity = serializationEvent.getEntity();
-		Session session = getSupportedEntityManager(entity.getClass().getName()).unwrap(Session.class);
+		Session session = getSupportedEntityManager(Hibernate.getClass(entity).getName()).unwrap(Session.class);
 		session.flush();
 		if (needRefresh(session, entity)) {
 			session.refresh(entity);

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/listeners/hbn/change/notifications/TemplateProcessingServiceImpl.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/listeners/hbn/change/notifications/TemplateProcessingServiceImpl.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 import javax.persistence.metamodel.Attribute;
 import lombok.Getter;
 import lombok.SneakyThrows;
+import org.hibernate.Hibernate;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.ResourceBundleMessageSource;
@@ -136,7 +137,7 @@ public class TemplateProcessingServiceImpl implements TemplateProcessingServiceE
 		if (version <= lastModified) {
 			return getConfiguration().getTemplate(key);
 		}
-		PropertyDescriptor propertyDescriptor = BeanUtils.getPropertyDescriptor(entity.getClass(), attributeName);
+		PropertyDescriptor propertyDescriptor = BeanUtils.getPropertyDescriptor(Hibernate.getClass(entity), attributeName);
 		String template = (String) propertyDescriptor.getReadMethod().invoke(entity);
 		if (template == null) {
 			template = "";

--- a/tesler-model/tesler-model-ui/pom.xml
+++ b/tesler-model/tesler-model-ui/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-model-ui</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Model UI</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-model-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-model-base/pom.xml</relativePath>
   </parent>
 

--- a/tesler-plugin/pom.xml
+++ b/tesler-plugin/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tesler-plugin</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <name>IO Tesler - Plugin</name>
 
     <parent>
         <groupId>io.tesler</groupId>
         <artifactId>tesler-base</artifactId>
-        <version>3.0.0.M8.0-SNAPSHOT</version>
+        <version>3.0.0.M8.2-SNAPSHOT</version>
         <relativePath>../tesler-base/pom.xml</relativePath>
     </parent>
 

--- a/tesler-testing/pom.xml
+++ b/tesler-testing/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-testing</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0.M8.0-SNAPSHOT</version>
+  <version>3.0.0.M8.2-SNAPSHOT</version>
   <name>IO Tesler - Testing</name>
 
   <parent>
     <groupId>io.tesler</groupId>
     <artifactId>tesler-base</artifactId>
-    <version>3.0.0.M8.0-SNAPSHOT</version>
+    <version>3.0.0.M8.2-SNAPSHOT</version>
     <relativePath>../tesler-base/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Entity retrieved from lazy initialized fields can have hibernate proxy class. To support this entities in JpaDao tesler should retrieve original class (not proxy)