### PR TITLE
opportunity to define roles (for which view is available) directly in .view.json

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/metahotreload/conf/MetaHotReloadConfiguration.java
+++ b/tesler-core/src/main/java/io/tesler/core/metahotreload/conf/MetaHotReloadConfiguration.java
@@ -47,6 +47,7 @@ public class MetaHotReloadConfiguration {
 
 	@Bean
 	public MetaHotReloadService refreshMeta(
+			MetaConfigurationProperties config,
 			MetaResourceReaderService metaResourceReaderService,
 			InternalAuthorizationService authzService,
 			TransactionService txService,
@@ -57,6 +58,7 @@ public class MetaHotReloadConfiguration {
 			ScreenAndNavigationGroupAndNavigationViewUtil screenAndNavigationGroupAndNavigationViewUtil,
 			BcUtil bcUtil) {
 		return new MetaHotReloadServiceImpl(
+				config,
 				metaResourceReaderService,
 				authzService,
 				txService,

--- a/tesler-core/src/main/java/io/tesler/core/metahotreload/conf/properties/MetaConfigurationProperties.java
+++ b/tesler-core/src/main/java/io/tesler/core/metahotreload/conf/properties/MetaConfigurationProperties.java
@@ -35,6 +35,8 @@ public class MetaConfigurationProperties {
 
 	private boolean devPanelEnabled = false;
 
+	private boolean viewAllowedRolesEnabled = false;
+
 	@NotNull(message = "Path to meta files directory. Supports file: or classpath: prefix. "
 			+ "Example of usage is: applicationContext.getResources(directory + widgetPath)")
 	private String directory = "classpath*:db/migration/liquibase/data/latest";

--- a/tesler-core/src/main/java/io/tesler/core/metahotreload/dto/ViewSourceDTO.java
+++ b/tesler-core/src/main/java/io/tesler/core/metahotreload/dto/ViewSourceDTO.java
@@ -21,6 +21,7 @@
 package io.tesler.core.metahotreload.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,6 +50,14 @@ public class ViewSourceDTO {
 	private JsonNode options;
 
 	private List<ViewWidgetSourceDTO> widgets;
+
+	/**
+	 * Inspired with JSR-250 and spring @RolesAllowed annotation.
+	 * Actually has same meaning, except the case when rolesAllowed is not defined.
+	 * While absence of @RolesAllowed means availability for all roles,
+	 * absence of rolesAllowed: [] in json means unavailability for all roles.
+	 */
+	private List<String> rolesAllowed = new ArrayList<>();
 
 	@Getter
 	@Setter

--- a/tesler-core/src/main/java/io/tesler/core/service/impl/ResponsibilitiesServiceImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/impl/ResponsibilitiesServiceImpl.java
@@ -25,6 +25,7 @@ import io.tesler.core.service.ResponsibilitiesService;
 import io.tesler.model.core.dao.JpaDao;
 import io.tesler.model.core.entity.Department;
 import io.tesler.model.core.entity.Responsibilities;
+import io.tesler.model.core.entity.Responsibilities.ResponsibilityType;
 import io.tesler.model.core.entity.Responsibilities_;
 import io.tesler.model.core.entity.User;
 import java.util.HashSet;
@@ -40,7 +41,7 @@ public class ResponsibilitiesServiceImpl implements ResponsibilitiesService {
 
 	private final JpaDao jpaDao;
 
-	private List<Responsibilities> getListByUserList(User user, LOV userRole, String responsibilityType) {
+	private List<Responsibilities> getListByUserList(User user, LOV userRole, ResponsibilityType responsibilityType) {
 		// В листе может быть не более одной записи
 		return jpaDao.getList(
 				Responsibilities.class,
@@ -53,7 +54,7 @@ public class ResponsibilitiesServiceImpl implements ResponsibilitiesService {
 	}
 
 	public Map<String, Boolean> getListRespByUser(User user, LOV userRole) {
-		return getListByUserList(user, userRole, "VIEW")
+		return getListByUserList(user, userRole, ResponsibilityType.VIEW)
 				.stream()
 				.collect(
 						Collectors.toMap(
@@ -65,7 +66,7 @@ public class ResponsibilitiesServiceImpl implements ResponsibilitiesService {
 	}
 
 	public String getListScreensByUser(User user, LOV userRole) {
-		return getListByUserList(user, userRole, "SCREEN")
+		return getListByUserList(user, userRole, ResponsibilityType.SCREEN)
 				.stream()
 				.map(Responsibilities::getScreens)
 				.filter(StringUtils::isNotBlank)
@@ -81,7 +82,7 @@ public class ResponsibilitiesServiceImpl implements ResponsibilitiesService {
 						(root, cb) -> root.get(Responsibilities_.view),
 						(root, cq, cb) -> cb.and(
 								cb.equal(root.get(Responsibilities_.departmentId), department.getId()),
-								cb.equal(root.get(Responsibilities_.responsibilityType), "VIEW")
+								cb.equal(root.get(Responsibilities_.responsibilityType), ResponsibilityType.VIEW)
 						)
 				)
 		);

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/dao/JpaDao.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/dao/JpaDao.java
@@ -59,6 +59,8 @@ public interface JpaDao {
 
 	<T> T save(Object entity);
 
+	<T> List<T> saveAll(List<T> entities);
+
 	<T extends BaseEntity> T evict(T o);
 
 	void flush();

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/dao/impl/JpaDaoImpl.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/dao/impl/JpaDaoImpl.java
@@ -230,6 +230,14 @@ public class JpaDaoImpl implements JpaDao {
 	}
 
 	@Override
+	public <T> List<T> saveAll(List<T> entities) {
+		return entities
+				.stream()
+				.map(this::<T>save)
+				.collect(Collectors.toList());
+	}
+
+	@Override
 	public <T extends BaseEntity> T evict(T o) {
 		getSupportedEntityManager(Hibernate.getClass(o).getName()).unwrap(Session.class).evict(o);
 		return o;

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/Responsibilities.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/Responsibilities.java
@@ -23,12 +23,15 @@ package io.tesler.model.core.entity;
 import io.tesler.api.data.dictionary.LOV;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.Type;
 
@@ -37,6 +40,7 @@ import org.hibernate.annotations.Type;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Accessors(chain = true)
 @Table(name = "RESPONSIBILITIES")
 public class Responsibilities extends BaseEntity {
 
@@ -50,7 +54,8 @@ public class Responsibilities extends BaseEntity {
 	private String view;
 
 	@Column(name = "RESP_TYPE")
-	private String responsibilityType;
+	@Enumerated(EnumType.STRING)
+	private ResponsibilityType responsibilityType;
 
 	@Column(name = "READ_ONLY")
 	private boolean readOnly;
@@ -61,5 +66,10 @@ public class Responsibilities extends BaseEntity {
 
 	@Formula("(SELECT views.TITLE FROM views WHERE views.NAME = RESPONSIBILITIES)")
 	private String viewTitle;
+
+	public enum ResponsibilityType {
+		VIEW,
+		SCREEN
+	}
 
 }


### PR DESCRIPTION
1) new config param tesler.meta.viewAllowedRolesEnabled (false by deault) added.
2) viewAllowedRolesEnabled = false - old behaivior. Means that responsibilities should be provided for tesler in responsibilities table (with liquibase)
3) viewAllowedRolesEnabledView = true - new behaivior.
 3.1) availability for role now should be defined directly in .view.json meta files in new field "rolesAllowed" : [] .
 3.2) Screen availability for role is calculated automatically (if at least one view is available for role, then screen is calculated as available for role too).
 3.4) responsibilities table is cleaned on app start and filled based on 3.1 and 3.2 logic