### PR TITLE
Support single Servlet configuration, wich is common default for springboot app

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/config/APIConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/APIConfig.java
@@ -23,6 +23,7 @@ package io.tesler.core.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tesler.api.service.LocaleService;
 import io.tesler.api.service.session.CoreSessionService;
+import io.tesler.core.config.properties.APIProperties;
 import io.tesler.core.controller.http.FillLogParametersInterceptor;
 import io.tesler.core.controller.param.resolvers.LocaleParameterArgumentResolver;
 import io.tesler.core.controller.param.resolvers.PageParameterArgumentResolver;
@@ -32,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -48,6 +50,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableWebMvc
 @ControllerScan({"io.tesler.core.controller"})
 @AllArgsConstructor
+@EnableConfigurationProperties(APIProperties.class)
 public class APIConfig implements WebMvcConfigurer {
 
 	protected final FillLogParametersInterceptor debugModeInterceptor;

--- a/tesler-core/src/main/java/io/tesler/core/config/UIConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/UIConfig.java
@@ -20,6 +20,9 @@
 
 package io.tesler.core.config;
 
+import io.tesler.core.config.properties.UIProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -28,20 +31,34 @@ import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerViewResolver;
 
-
+@EnableConfigurationProperties(UIProperties.class)
 @EnableWebMvc
 public class UIConfig implements WebMvcConfigurer {
 
+	@Autowired
+	private UIProperties uiProperties;
+
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {
-		registry.addResourceHandler("/**").addResourceLocations("classpath:/ui/");
+		if (uiProperties.getUseServletContextPath()) {
+			registry.addResourceHandler("/**").addResourceLocations("classpath:/ui/");
+		} else {
+			registry.addResourceHandler(uiProperties.getPath() + "/**").addResourceLocations("classpath:/ui/");
+		}
 	}
 
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
-		registry.addRedirectViewController("/ui", "/ui/");
-		registry.addViewController("/").setViewName("index");
-		registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		if (uiProperties.getUseServletContextPath()) {
+			registry.addRedirectViewController("/ui", "/ui/");
+			registry.addViewController("/").setViewName("index");
+			registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		} else {
+			registry.addRedirectViewController("/", uiProperties.getPath() + "/");
+			registry.addRedirectViewController(uiProperties.getPath(), uiProperties.getPath() + "/");
+			registry.addViewController(uiProperties.getPath() + "/").setViewName("index");
+			registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		}
 	}
 
 	@Bean

--- a/tesler-core/src/main/java/io/tesler/core/config/properties/APIProperties.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/properties/APIProperties.java
@@ -1,0 +1,46 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2019 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties("tesler.api")
+public class APIProperties {
+
+	public static final String TESLER_API_PATH_SPEL = "#{ (${tesler.api.use-servlet-context-path} == true) ? '':  '${tesler.api.path}'}";
+
+	/**
+	 ** useServletContextPath = true is deprecated, and it means you will create 2 servlets (for api with context-path = '/api/v1' and for ui with context-path = '/ui'). This is very complex and non-common approach for springboot apps.
+	 * useServletContextPath = false, means your app have only 1 servlet with context-path = '' , so tesler needs to add '/api/v1' prefix to rest controllers explicitly. Also tesler will configure ui static content delivery in a slightly different way
+	 */
+	@Deprecated
+	private Boolean useServletContextPath = false;
+
+	/**
+	** Use only when useServletContextPath = false;
+	 */
+	private String path = "/api/v1";
+
+}

--- a/tesler-core/src/main/java/io/tesler/core/config/properties/UIProperties.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/properties/UIProperties.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2019 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties("tesler.ui")
+public class UIProperties {
+
+	/**
+	 ** useServletContextPath = true is deprecated, and it means you will create 2 servlets (for api with context-path = '/api/v1' and for ui with context-path = '/ui'). This is very complex and non-common approach for springboot apps.
+	 * useServletContextPath = false, means your app have only 1 servlet with context-path = '' , so tesler needs to add '/api/v1' prefix to rest controllers explicitly. Also tesler will configure ui static content delivery in a slightly different way
+	 */
+	@Deprecated
+	private Boolean useServletContextPath = false;
+
+	/**
+	 ** Use only when useServletContextPath = false;
+	 */
+	private String path = "/ui";
+
+}

--- a/tesler-core/src/main/java/io/tesler/core/controller/BcRegistryController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/BcRegistryController.java
@@ -20,6 +20,7 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 import io.tesler.core.crudma.bc.BcRegistry;
@@ -32,7 +33,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("bc-registry")
+@RequestMapping(TESLER_API_PATH_SPEL + "/bc-registry")
 public class BcRegistryController {
 
 	@Autowired

--- a/tesler-core/src/main/java/io/tesler/core/controller/FileController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/FileController.java
@@ -21,6 +21,7 @@
 package io.tesler.core.controller;
 
 import static io.tesler.api.util.i18n.ErrorMessageSource.errorMessage;
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
 
 import io.tesler.api.exception.ServerException;
 import io.tesler.core.dto.ResponseBuilder;
@@ -52,7 +53,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "file")
+@RequestMapping(TESLER_API_PATH_SPEL + "/file")
 public class FileController {
 
 	@Autowired

--- a/tesler-core/src/main/java/io/tesler/core/controller/LoginController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/LoginController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.api.data.dictionary.LOV;
 import io.tesler.api.service.LocaleService;
 import io.tesler.api.service.session.CoreSessionService;
@@ -53,6 +55,7 @@ import org.springframework.web.servlet.LocaleResolver;
 @RequiredArgsConstructor
 @Slf4j
 @RestController
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class LoginController {
 
 	private final LocaleService localeService;

--- a/tesler-core/src/main/java/io/tesler/core/controller/MetaHotReloadController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/MetaHotReloadController.java
@@ -21,6 +21,8 @@
 package io.tesler.core.controller;
 
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.api.service.tx.TransactionService;
 import io.tesler.api.util.Invoker;
 import io.tesler.core.config.CacheConfig;
@@ -32,8 +34,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("bc-registry")
 @RequiredArgsConstructor
+@RequestMapping(TESLER_API_PATH_SPEL + "/bc-registry")
 public class MetaHotReloadController {
 
 	final MetaHotReloadService metaHotReloadService;

--- a/tesler-core/src/main/java/io/tesler/core/controller/RouterController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/RouterController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.core.controller.http.AJAXRedirectStrategy;
 import io.tesler.core.service.RouterService;
 import java.io.IOException;
@@ -35,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class RouterController {
 
 	private final RouterService routerService;

--- a/tesler-core/src/main/java/io/tesler/core/controller/ScreenController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/ScreenController.java
@@ -20,17 +20,21 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.core.dto.data.view.ScreenResponsibility;
 import io.tesler.core.service.ScreenResponsibilityService;
 import io.tesler.core.util.session.SessionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class ScreenController {
 
 	private final ScreenResponsibilityService screenResponsibilityService;

--- a/tesler-core/src/main/java/io/tesler/core/controller/UniversalAssociateController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/UniversalAssociateController.java
@@ -20,6 +20,7 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static io.tesler.api.util.i18n.InfoMessageSource.infoMessage;
 
@@ -44,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "associate/**")
+@RequestMapping(value = TESLER_API_PATH_SPEL + "/associate/**")
 public class UniversalAssociateController {
 
 	@Autowired

--- a/tesler-core/src/main/java/io/tesler/core/controller/UniversalCustomActionController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/UniversalCustomActionController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.core.controller.param.QueryParameters;
 import io.tesler.core.crudma.CrudmaActionHolder;
 import io.tesler.core.crudma.CrudmaActionHolder.CrudmaAction;
@@ -38,7 +40,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "custom-action/**")
+@RequestMapping(value = TESLER_API_PATH_SPEL + "/custom-action/**")
 public class UniversalCustomActionController {
 
 	@Autowired

--- a/tesler-core/src/main/java/io/tesler/core/controller/UniversalDataController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/UniversalDataController.java
@@ -21,6 +21,7 @@
 package io.tesler.core.controller;
 
 import static io.tesler.api.util.i18n.InfoMessageSource.infoMessage;
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
 
 import io.tesler.api.data.ResultPage;
 import io.tesler.api.data.dto.DataResponseDTO;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class UniversalDataController {
 
 	@Autowired

--- a/tesler-core/src/main/java/io/tesler/core/controller/UniversalRowMetaController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/UniversalRowMetaController.java
@@ -21,6 +21,7 @@
 package io.tesler.core.controller;
 
 import static io.tesler.api.util.i18n.InfoMessageSource.infoMessage;
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
 
 import io.tesler.core.controller.param.QueryParameters;
 import io.tesler.core.crudma.CrudmaActionHolder;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class UniversalRowMetaController {
 
 	private final CrudmaGateway crudmaGateway;

--- a/tesler-core/src/main/java/io/tesler/core/controller/UserController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/UserController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.api.data.PageSpecification;
 import io.tesler.api.data.dto.DataResponseDTO;
 import io.tesler.core.dto.ResponseBuilder;
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class UserController {
 
 	@Autowired

--- a/tesler-core/src/main/java/io/tesler/core/controller/ViewController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/ViewController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.core.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tesler.core.crudma.bc.BcRegistry;
 import io.tesler.core.dto.ResponseBuilder;
@@ -36,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class ViewController {
 
 	@Qualifier("teslerObjectMapper")

--- a/tesler-starters/tesler-starter-notifications/tesler-starter-notifications/src/main/java/io/tesler/notifications/controller/NotificationController.java
+++ b/tesler-starters/tesler-starter-notifications/tesler-starter-notifications/src/main/java/io/tesler/notifications/controller/NotificationController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.notifications.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.api.data.PageSpecification;
 import io.tesler.api.data.ResultPage;
 import io.tesler.core.dto.ResponseBuilder;
@@ -41,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 
 @RestController
-@RequestMapping("/notification")
+@RequestMapping(TESLER_API_PATH_SPEL)
 public class NotificationController {
 
 	@Autowired

--- a/tesler-starters/tesler-starter-notifications/tesler-starter-notifications/src/main/java/io/tesler/notifications/controller/NotificationController.java
+++ b/tesler-starters/tesler-starter-notifications/tesler-starter-notifications/src/main/java/io/tesler/notifications/controller/NotificationController.java
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 
 @RestController
-@RequestMapping(TESLER_API_PATH_SPEL)
+@RequestMapping(TESLER_API_PATH_SPEL + "/notification")
 public class NotificationController {
 
 	@Autowired

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/controller/SQLController.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/controller/SQLController.java
@@ -20,6 +20,8 @@
 
 package io.tesler.sqlbc.controller;
 
+import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
+
 import io.tesler.api.data.PageSpecification;
 import io.tesler.api.data.ResultPage;
 import io.tesler.api.service.tx.TransactionService;
@@ -49,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
-@RequestMapping("sql")
+@RequestMapping(TESLER_API_PATH_SPEL + "/sql")
 public class SQLController {
 
 	private static final int DEFAULT_PAGE_NUMBER = 1;


### PR DESCRIPTION
new property useServletContextPath (default = false) is introduced.

1) (LEGACY) useServletContextPath = true is deprecated, and it means you will create 2 servlets (for api with context-path = '/api/v1' and for ui with context-path = '/ui'). This is very complex and non-common approach for springboot apps.

2) (RECOMMENDED) useServletContextPath = false, means your app have only 1 servlet with context-path = '' , so tesler needs to add '/api/v1' prefix to rest controllers explicitly. Also tesler will configure ui static content delivery in a slightly different way