### PR TITLE
Add support of external beans (non-tesler, e.g. spring, jpa, jackson and so on) injection by name from application.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn clean install -Pcoverage sonar:sonar javadoc:aggregate -Dsonar.organization=tesler-platform -Dsonar.projectKey=tesler-platform_tesler -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+        run: mvn clean install -Pcoverage sonar:sonar -Dsonar.organization=tesler-platform -Dsonar.projectKey=tesler-platform_tesler -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/tesler-api/pom.xml
+++ b/tesler-api/pom.xml
@@ -20,6 +20,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>

--- a/tesler-api/src/main/java/io/tesler/api/config/TeslerBeanProperties.java
+++ b/tesler-api/src/main/java/io/tesler/api/config/TeslerBeanProperties.java
@@ -1,0 +1,46 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2019 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.api.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "tesler.bean")
+public class TeslerBeanProperties {
+
+	/**
+	 * We use "dataSource" by default to ease springboot-starter-jpa (and so on) integration out of the box.
+	 * Set "primaryDS" legacy value explicitly, if you need this.
+	 */
+	private String dataSource = "dataSource";
+
+	/**
+	 * We use "entityManagerFactory" by default to ease springboot-starter-jpa (and so on) integration out of the box.
+	 * Set "teslerEntityManagerFactory" legacy value explicitly, if you need this.
+	 */
+	private String entityManagerFactory = "entityManagerFactory";
+
+}

--- a/tesler-base/pom.xml
+++ b/tesler-base/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tesler-base</artifactId>
@@ -265,6 +266,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+            <doclint>none</doclint>
+          </configuration>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/tesler-core/src/main/java/io/tesler/core/config/CoreApplicationConfig.java
+++ b/tesler-core/src/main/java/io/tesler/core/config/CoreApplicationConfig.java
@@ -20,6 +20,7 @@
 
 package io.tesler.core.config;
 
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.core.metahotreload.conf.MetaHotReloadConfiguration;
 import io.tesler.core.service.ResponsibilitiesService;
 import io.tesler.core.service.impl.ResponsibilitiesServiceImpl;
@@ -29,6 +30,7 @@ import io.tesler.model.core.service.BaseEntityListenerDelegate;
 import io.tesler.model.core.service.TeslerBaseEntityListenerDelegate;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
@@ -40,6 +42,7 @@ import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 @ImportAutoConfiguration({
 		MetaHotReloadConfiguration.class
 })
+@EnableConfigurationProperties(TeslerBeanProperties.class)
 public class CoreApplicationConfig {
 
 	@Bean

--- a/tesler-core/src/main/java/io/tesler/core/dao/impl/BaseDAOImpl.java
+++ b/tesler-core/src/main/java/io/tesler/core/dao/impl/BaseDAOImpl.java
@@ -32,9 +32,7 @@ import io.tesler.model.core.dao.impl.JpaDaoImpl;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,19 +57,15 @@ public class BaseDAOImpl extends JpaDaoImpl implements BaseDAO {
 
 	private final List<ClassifyDataProvider> providers;
 
-	private final Database primaryDatabase;
-
 	public BaseDAOImpl(
 			Set<EntityManager> entityManagers,
 			TransactionService txService,
 			Optional<IPdqExtractor> pdqExtractor,
-			List<ClassifyDataProvider> providers,
-			@Qualifier("primaryDatabase") Database primaryDatabase
+			List<ClassifyDataProvider> providers
 	) {
 		super(entityManagers, txService);
 		this.pdqExtractor = pdqExtractor;
 		this.providers = providers;
-		this.primaryDatabase = primaryDatabase;
 	}
 
 	private Specification getPdqSearchSpec(final QueryParameters queryParameters) {

--- a/tesler-core/src/main/java/io/tesler/core/service/file/CustomSourceFileService.java
+++ b/tesler-core/src/main/java/io/tesler/core/service/file/CustomSourceFileService.java
@@ -21,6 +21,7 @@
 package io.tesler.core.service.file;
 
 import io.tesler.api.exception.ServerException;
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.core.exception.ClientException;
 import io.tesler.model.core.dao.JpaDao;
 import io.tesler.model.core.entity.FileDatasource;
@@ -35,7 +36,7 @@ import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -53,7 +54,8 @@ public class CustomSourceFileService {
 	private final JpaDao jpaDao;
 
 	@Autowired
-	public CustomSourceFileService(@Qualifier("primaryDS") DataSource dataSource, JpaDao jpaDao) {
+	public CustomSourceFileService(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties, JpaDao jpaDao) {
+		DataSource dataSource = applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class);
 		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 		this.jpaDao = jpaDao;
 	}

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/User.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/entity/User.java
@@ -46,7 +46,7 @@ import org.hibernate.envers.NotAudited;
 @Table(name = "users") // users, а не user, т.к. это служебное слово oracle
 @Getter
 @Setter
-public class User extends BaseEntity /*TODO>>IBORISENKO>>this should be moved to project level!!!>> implements IAccessorSupplier*/ {
+public class User extends BaseEntity {
 
 	private String login;
 

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/listeners/hbn/DatabaseListener.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/listeners/hbn/DatabaseListener.java
@@ -27,6 +27,7 @@ import static org.hibernate.event.spi.EventType.POST_DELETE;
 import static org.hibernate.event.spi.EventType.POST_INSERT;
 import static org.hibernate.event.spi.EventType.POST_UPDATE;
 
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.model.core.listeners.hbn.change.ChangeInterceptor;
 import io.tesler.model.core.listeners.hbn.flush.FlushInterceptor;
 import javax.annotation.PostConstruct;
@@ -49,7 +50,7 @@ import org.hibernate.event.spi.PostUpdateEvent;
 import org.hibernate.event.spi.PostUpdateEventListener;
 import org.hibernate.persister.entity.EntityPersister;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 
@@ -59,8 +60,10 @@ public class DatabaseListener implements
 		FlushEntityEventListener, FlushEventListener, AutoFlushEventListener {
 
 	@Autowired
-	@Qualifier("teslerEntityManagerFactory")
-	private EntityManagerFactory emf;
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private TeslerBeanProperties teslerBeanProperties;
 
 	@Autowired
 	private ChangeInterceptor changeInterceptor;
@@ -114,7 +117,10 @@ public class DatabaseListener implements
 	}
 
 	private EventListenerRegistry getRegistry() {
-		SessionFactoryImplementor implementor = emf.unwrap(SessionFactoryImplementor.class);
+		SessionFactoryImplementor implementor = applicationContext.getBean(
+				teslerBeanProperties.getEntityManagerFactory(),
+				EntityManagerFactory.class
+		).unwrap(SessionFactoryImplementor.class);
 		return implementor.getServiceRegistry().getService(EventListenerRegistry.class);
 	}
 

--- a/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/tx/TeslerJpaTransactionManagerForceActiveAware.java
+++ b/tesler-model/tesler-model-core/src/main/java/io/tesler/model/core/tx/TeslerJpaTransactionManagerForceActiveAware.java
@@ -20,8 +20,10 @@
 
 package io.tesler.model.core.tx;
 
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.api.service.tx.ITransactionStatus;
 import javax.persistence.EntityManagerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -30,11 +32,19 @@ import org.springframework.transaction.support.TransactionSynchronizationAdapter
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 
-public class JpaTransactionManagerCustom extends JpaTransactionManager {
+public class TeslerJpaTransactionManagerForceActiveAware extends JpaTransactionManager {
 
 	private final ITransactionStatus txStatus;
 
-	public JpaTransactionManagerCustom(EntityManagerFactory emf, ITransactionStatus txStatus) {
+	public TeslerJpaTransactionManagerForceActiveAware(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties, ITransactionStatus txStatus) {
+		super(applicationContext.getBean(
+				teslerBeanProperties.getEntityManagerFactory(),
+				EntityManagerFactory.class
+		));
+		this.txStatus = txStatus;
+	}
+
+	public TeslerJpaTransactionManagerForceActiveAware(EntityManagerFactory emf, ITransactionStatus txStatus) {
 		super(emf);
 		this.txStatus = txStatus;
 	}

--- a/tesler-starters/tesler-starter-quartz/README.md
+++ b/tesler-starters/tesler-starter-quartz/README.md
@@ -19,6 +19,20 @@ In your pom.xml add
     <artifactId>tesler-starter-quartz</artifactId>
 </dependency>
 ```
+In your app add bean corresponding to your database vendor:
+```
+@Bean(name = "primaryDatabase")
+Database primaryDatabase() {
+	return Database.POSTGRESQL;
+}
+```
+or 
+```
+@Bean(name = "primaryDatabase")
+Database primaryDatabase() {
+	return Database.ORACLE;
+}
+```
 ### Liquibase migrations
 
 In your liquibase change log check following line is included:

--- a/tesler-starters/tesler-starter-quartz/src/test/java/io/tesler/quartz/config/SchedulerConfigTest.java
+++ b/tesler-starters/tesler-starter-quartz/src/test/java/io/tesler/quartz/config/SchedulerConfigTest.java
@@ -20,6 +20,7 @@
 
 package io.tesler.quartz.config;
 
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.quartz.impl.QuartzJobFactory;
 import io.tesler.quartz.impl.QuartzSchedulerListener;
 import org.junit.jupiter.api.Assertions;
@@ -75,14 +76,14 @@ class SchedulerConfigTest {
 
 	@Test
 	void testQuartzScheduler() {
-		SchedulerFactoryBean result = schedulerConfig.quartzScheduler(null, Database.DEFAULT);
+		SchedulerFactoryBean result = schedulerConfig.quartzScheduler(applicationContext, new TeslerBeanProperties(), Database.DEFAULT);
 		Assertions.assertEquals(SchedulerFactoryBean.class, result.getClass());
 	}
 
 	@Test
 	void testQuartzSchedulerService() {
 		TransactionProxyFactoryBean result = schedulerConfig.quartzSchedulerService(
-				schedulerConfig.quartzScheduler(null, Database.DEFAULT)
+				schedulerConfig.quartzScheduler(applicationContext, new TeslerBeanProperties(), Database.DEFAULT)
 		);
 		Assertions.assertEquals(TransactionProxyFactoryBean.class, result.getClass());
 	}

--- a/tesler-starters/tesler-starter-sqlbc/README.md
+++ b/tesler-starters/tesler-starter-sqlbc/README.md
@@ -19,6 +19,20 @@ In your pom.xml add
     <artifactId>tesler-starter-sqlbc</artifactId>
 </dependency>
 ```
+In your app add bean corresponding to your database vendor:
+```
+@Bean(name = "primaryDatabase")
+Database primaryDatabase() {
+	return Database.POSTGRESQL;
+}
+```
+or
+```
+@Bean(name = "primaryDatabase")
+Database primaryDatabase() {
+	return Database.ORACLE;
+}
+```
 ### Liquibase migrations
 
 In your liquibase change log check following line is included:

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/controller/SQLController.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/controller/SQLController.java
@@ -22,6 +22,7 @@ package io.tesler.sqlbc.controller;
 
 import static io.tesler.core.config.properties.APIProperties.TESLER_API_PATH_SPEL;
 
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.api.data.PageSpecification;
 import io.tesler.api.data.ResultPage;
 import io.tesler.api.service.tx.TransactionService;
@@ -41,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.CallableStatementCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,8 +70,8 @@ public class SQLController {
 	private ResponseBuilder resp;
 
 	@Autowired
-	public SQLController(@Qualifier("primaryDS") DataSource dataSource) {
-		jdbcTemplate = new JdbcTemplate(dataSource);
+	public SQLController(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties) {
+		jdbcTemplate = new JdbcTemplate(applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class));
 	}
 
 	@RequestMapping(method = RequestMethod.POST, value = "execute")

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/crudma/SqlBcCreator.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/crudma/SqlBcCreator.java
@@ -22,6 +22,7 @@ package io.tesler.sqlbc.crudma;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.api.exception.ServerException;
 import io.tesler.core.controller.param.SearchOperation;
 import io.tesler.sqlbc.crudma.SqlBcDescription;
@@ -42,6 +43,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
@@ -56,10 +58,9 @@ public class SqlBcCreator {
 
 	private final ObjectMapper objectMapper;
 
-	public SqlBcCreator(@Qualifier("primaryDS") DataSource dataSource,
-			@Qualifier("teslerObjectMapper") ObjectMapper objectMapper
+	public SqlBcCreator(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties, @Qualifier("teslerObjectMapper") ObjectMapper objectMapper
 	) {
-		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class));
 		this.objectMapper = objectMapper;
 	}
 

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/dao/SqlBcJdbcTemplate.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/dao/SqlBcJdbcTemplate.java
@@ -33,7 +33,6 @@ import javax.sql.DataSource;
 
 import io.tesler.sqlbc.exception.BadSqlComponentException;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.ResultSetExtractor;
@@ -50,8 +49,9 @@ public final class SqlBcJdbcTemplate {
 
 	private final Database database;
 
-	public SqlBcJdbcTemplate(SessionService sessionService, @Qualifier("primaryDS") DataSource dataSource,
-			@Qualifier("primaryDatabase") Database primaryDatabase) {
+	public SqlBcJdbcTemplate(SessionService sessionService,
+			DataSource dataSource,
+			Database primaryDatabase) {
 		this.sessionService = sessionService;
 		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 		this.database = primaryDatabase;

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/dao/SqlComponentDao.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/dao/SqlComponentDao.java
@@ -20,6 +20,7 @@
 
 package io.tesler.sqlbc.dao;
 
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.api.data.ResultPage;
 import io.tesler.core.controller.param.QueryParameters;
 import io.tesler.core.crudma.bc.BusinessComponent;
@@ -35,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cglib.beans.BeanGenerator;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.stereotype.Service;
@@ -46,9 +48,9 @@ public class SqlComponentDao {
 	private final SqlBcJdbcTemplate jdbcTemplate;
 
 	@Autowired
-	public SqlComponentDao(SessionService sessionService, @Qualifier("primaryDS") DataSource dataSource,
+	public SqlComponentDao(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties, SessionService sessionService,
 			@Qualifier("primaryDatabase") Database primaryDatabase) {
-		jdbcTemplate = new SqlBcJdbcTemplate(sessionService, dataSource, primaryDatabase);
+		jdbcTemplate = new SqlBcJdbcTemplate(sessionService, applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class), primaryDatabase);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/dao/binds/SqlNamedParameterQueryBinderImpl.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/dao/binds/SqlNamedParameterQueryBinderImpl.java
@@ -21,6 +21,7 @@
 package io.tesler.sqlbc.dao.binds;
 
 import com.google.common.collect.ImmutableMap;
+import io.tesler.api.config.TeslerBeanProperties;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -28,7 +29,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.SqlParameter;
 import org.springframework.jdbc.core.namedparam.NamedParameterUtils;
 import org.springframework.jdbc.core.namedparam.ParsedSql;
@@ -42,11 +43,10 @@ public class SqlNamedParameterQueryBinderImpl implements SqlNamedParameterQueryB
 			.put(Timestamp.class, "{ts '%s'}")
 			.put(String.class, "'%s'")
 			.build();
-
 	private final DataSource dataSource;
 
-	public SqlNamedParameterQueryBinderImpl(@Qualifier("primaryDS") DataSource dataSource) {
-		this.dataSource = dataSource;
+	public SqlNamedParameterQueryBinderImpl(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties) {
+		this.dataSource = applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class);
 	}
 
 	@Override

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/export/base/JdbcTemplateSqlExporter.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/export/base/JdbcTemplateSqlExporter.java
@@ -21,6 +21,7 @@
 package io.tesler.sqlbc.export.base;
 
 import com.google.common.collect.Lists;
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.sqlbc.export.base.model.ExportedRecord;
 import io.tesler.sqlbc.export.base.model.TableMeta;
 import io.tesler.sqlbc.dao.SqlFieldType;
@@ -32,7 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.namedparam.EmptySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -44,8 +45,8 @@ public class JdbcTemplateSqlExporter {
 
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 
-	public JdbcTemplateSqlExporter(@Qualifier("primaryDS") final DataSource dataSource) {
-		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	public JdbcTemplateSqlExporter(ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties) {
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class));
 	}
 
 	public List<ExportedRecord> queryForMap(final String tableName,

--- a/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/export/sql/SqlExportQueryBuilder.java
+++ b/tesler-starters/tesler-starter-sqlbc/src/main/java/io/tesler/sqlbc/export/sql/SqlExportQueryBuilder.java
@@ -21,6 +21,7 @@
 package io.tesler.sqlbc.export.sql;
 
 import com.google.common.collect.Lists;
+import io.tesler.api.config.TeslerBeanProperties;
 import io.tesler.sqlbc.export.base.JdbcTemplateSqlExporter;
 import io.tesler.sqlbc.export.base.Parameters;
 import io.tesler.sqlbc.export.sql.query.UpdateForeignKey;
@@ -31,7 +32,7 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import io.tesler.sqlbc.export.sql.query.Insert;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -43,11 +44,9 @@ public class SqlExportQueryBuilder {
 
 	private final JdbcTemplateSqlExporter jdbcTemplateSqlExporter;
 
-	SqlExportQueryBuilder(
-			@Qualifier("primaryDS") final DataSource dataSource,
-			final JdbcTemplateSqlExporter jdbcTemplateSqlExporter
+	SqlExportQueryBuilder(final JdbcTemplateSqlExporter jdbcTemplateSqlExporter, ApplicationContext applicationContext, TeslerBeanProperties teslerBeanProperties
 	) {
-		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(applicationContext.getBean(teslerBeanProperties.getDataSource(), DataSource.class));
 		this.jdbcTemplateSqlExporter = jdbcTemplateSqlExporter;
 	}
 

--- a/tesler-testing/pom.xml
+++ b/tesler-testing/pom.xml
@@ -67,11 +67,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
-      </plugin>
     </plugins>
   </build>
 

--- a/tesler-testing/src/test/java/io/tesler/testing/tests/BaseDAOAwareTest.java
+++ b/tesler-testing/src/test/java/io/tesler/testing/tests/BaseDAOAwareTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -67,8 +66,7 @@ public abstract class BaseDAOAwareTest extends AbstractTeslerTest {
 
 	protected final AtomicLong idSequence = new AtomicLong(Long.MIN_VALUE);
 
-	@PersistenceContext(unitName = "teslerEntityManagerFactory")
-	protected EntityManager entityManager;
+	protected List<EntityManager> entityManagers;
 
 	@Autowired
 	protected BaseDAO baseDAO;
@@ -141,11 +139,11 @@ public abstract class BaseDAOAwareTest extends AbstractTeslerTest {
 	}
 
 	private <T> AbstractProducedQuery<T> compile(Class<T> cls, Specification<T> spec) {
-		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaBuilder cb = entityManagers.get(0).getCriteriaBuilder();
 		CriteriaQuery<T> cq = cb.createQuery(cls);
 		Root<T> root = cq.from(cls);
 		cq.where(spec.toPredicate(root, cq, cb));
-		return (AbstractProducedQuery<T>) entityManager.createQuery(cq).unwrap(AbstractProducedQuery.class);
+		return (AbstractProducedQuery<T>) entityManagers.get(0).createQuery(cq).unwrap(AbstractProducedQuery.class);
 	}
 
 	private EntityKey createEntityKey(Class<?> cls, Serializable id) {
@@ -157,7 +155,7 @@ public abstract class BaseDAOAwareTest extends AbstractTeslerTest {
 	}
 
 	private String getModelName(Class<?> cls) {
-		return entityManager.getMetamodel().entity(cls).getName();
+		return entityManagers.get(0).getMetamodel().entity(cls).getName();
 	}
 
 	@Data


### PR DESCRIPTION
1) Problem: Tesler hardcodes bean names like "primaryDS", "teslerEntityManagerFactory" and so on. 
This leads to few problems: 
1.1) auto-created by spring-boot beans have different bean names - so tesler cannnot use them
1.2) users cannot create beans with their own names - so tesler cannnot use them

2) Solution: 
2.1) For non-tesler beans, e.g. for beans from external libraries (Spring, JPA, Jackson) Tesler can take bean names from application.yml (this fixes 1.1 and 1.2)
2.2) external bean names can have convenient defaults equal to bean names created by SpringBoot to work with springboot out-of-the-box