### PR TITLE
Sonarcloud reporting vulnerabilities; file service returns incorrect file name in dto

### DIFF
--- a/tesler-core/src/main/java/io/tesler/core/controller/RouterController.java
+++ b/tesler-core/src/main/java/io/tesler/core/controller/RouterController.java
@@ -45,7 +45,7 @@ public class RouterController {
 	private final AJAXRedirectStrategy redirectStrategy;
 
 	@RequestMapping(method = RequestMethod.GET, value = "/router/{type}/{id}")
-	protected void route(
+	public void route(
 			HttpServletRequest request,
 			HttpServletResponse response,
 			@PathVariable String type,

--- a/tesler-core/src/main/java/io/tesler/core/file/service/TeslerFileServiceSimple.java
+++ b/tesler-core/src/main/java/io/tesler/core/file/service/TeslerFileServiceSimple.java
@@ -67,7 +67,7 @@ public class TeslerFileServiceSimple implements TeslerFileService {
 		Path path = getPathFromId(id);
 		return new FileDownloadDto(
 				Files.readAllBytes(path),
-				path.getFileName().toString().substring(path.getFileName().toString().indexOf(UNIQUE_PREFIX_SEPARATOR)),
+				path.getFileName().toString().substring(0, path.getFileName().toString().indexOf(UNIQUE_PREFIX_SEPARATOR)),
 				Files.probeContentType(path)
 		);
 	}

--- a/tesler-core/src/main/java/io/tesler/core/file/service/TeslerFileServiceSimple.java
+++ b/tesler-core/src/main/java/io/tesler/core/file/service/TeslerFileServiceSimple.java
@@ -81,7 +81,8 @@ public class TeslerFileServiceSimple implements TeslerFileService {
 
 	@NonNull
 	private Path getPathFromId(@NonNull String id) {
-		return Paths.get(this.fileFolder + "/" + id);
+		Path fileId = Paths.get("/" + id).normalize();
+		return Paths.get(this.fileFolder + "/" + fileId);
 	}
 
 }

--- a/tesler-core/src/test/java/io/tesler/core/file/TeslerFileServiceSimpleTest.java
+++ b/tesler-core/src/test/java/io/tesler/core/file/TeslerFileServiceSimpleTest.java
@@ -1,0 +1,52 @@
+/*-
+ * #%L
+ * IO Tesler - Core
+ * %%
+ * Copyright (C) 2018 - 2021 Tesler Contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package io.tesler.core.file;
+
+import io.tesler.core.file.dto.FileDownloadDto;
+import io.tesler.core.file.service.TeslerFileService;
+import io.tesler.core.file.service.TeslerFileServiceSimple;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TeslerFileServiceSimpleTest {
+
+	@Test
+	@SneakyThrows
+	void download() {
+		String fileStorage = Paths.get(getClass().getResource("").toURI()).toAbsolutePath().toString();
+		String jacksonStorage = Paths.get(getClass().getResource("../../jackson").toURI()).toAbsolutePath().toString();
+		TeslerFileService service = new TeslerFileServiceSimple(fileStorage);
+		assertThatThrownBy(() -> {
+			FileDownloadDto dtoOutsideOfDirectory = service.download("../../jackson/InputField.json", null);
+		}).isInstanceOf(NoSuchFileException.class);
+		TeslerFileService jacksonService = new TeslerFileServiceSimple(jacksonStorage);
+		FileDownloadDto jacksonDto = jacksonService.download("InputField.json", null);
+		assertThat(jacksonDto.getName()).isEqualTo("InputField");
+		FileDownloadDto dto = service.download("download.txt", null);
+		assertThat(dto.getName()).isEqualTo("download");
+	}
+}

--- a/tesler-core/src/test/resources/io/tesler/core/file/download.txt
+++ b/tesler-core/src/test/resources/io/tesler/core/file/download.txt
@@ -1,0 +1,1 @@
+Download test


### PR DESCRIPTION
* Sonarcloud reports [security vulnerability](https://sonarcloud.io/project/issues?id=tesler-platform_tesler&pullRequest=217&resolved=false&types=VULNERABILITY) on the new [TeslerFileServiceSimple](https://github.com/tesler-platform/tesler/pull/217) implementation; the report is in fact correct, as argument `id` of string type and not checked for directory traversal for `download` and `remove` operation so it's possible to call those methods with "../../someFile" type of url and either access or remove files outside of intended folder

* `TeslerFileServiceSimple` erroneously assigns file extension as file name for `FileDownloadDto`

* `/router` endpoint is reported by sonarcloud as vulnerability as it's declared `protected` and AOP proxies are not applied to non-public proxies